### PR TITLE
Slim get_build_info; add editor lifecycle MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,29 @@ ue5 server agents --json                      # List registered AI agents
 
 See `ue5 server --help` for all available subcommands.
 
+### Log Locations
+
+All server state lives under `~/.ue5/`. Logs are stored per-project using a hash of the `.uproject` path:
+
+| File | Path | Contents |
+|------|------|----------|
+| Editor log | `~/.ue5/logs/<hash>/editor.log` | Captured editor stdout/stderr |
+| Build log | `~/.ue5/logs/<hash>/build.log` | UBT compiler output (errors, warnings, linker output) |
+| Daemon state | `~/.ue5/state.json` | Build history, accumulated features, active agents |
+
+The `<hash>` is the first 12 hex characters of `SHA-256(project_path)`. To read a build log directly:
+
+```bash
+cat ~/.ue5/logs/$(echo -n "/path/to/YourProject.uproject" | shasum -a 256 | cut -c1-12)/build.log
+```
+
+Or use the CLI, which resolves the hash for you:
+
+```bash
+ue5 server logs --level error          # Query captured editor logs
+ue5 server build-info --json           # Build status and history
+```
+
 ### Dashboard
 
 The daemon ships a web dashboard that shows real-time build status, editor instances, and connected AI agents. It starts automatically with the daemon on port **9516** (override with the `UE5_DASHBOARD_PORT` environment variable).

--- a/pkg/server/mcpserver.go
+++ b/pkg/server/mcpserver.go
@@ -5,9 +5,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
+	"github.com/Benbentwo/ue5/pkg"
 	"github.com/charmbracelet/log"
 	"github.com/mark3labs/mcp-go/mcp"
 	mcpserver "github.com/mark3labs/mcp-go/server"
@@ -162,13 +166,95 @@ func (w *mcpServerWrapper) registerTools() {
 		w.handleUnregisterAgent,
 	)
 
-	// Tool: get_build_info
+	// Tool: get_build_status — minimal polling response.
+	// Use this when waiting on a rebuild. Returns ID + prompt + status only.
+	// If status == "failed", call get_build_failure with the ID for details.
+	w.mcp.AddTool(
+		mcp.NewTool("get_build_status",
+			mcp.WithDescription("Minimal status check for the current build. "+
+				"Returns only {id, prompt, status} — designed for cheap polling. "+
+				"If status is 'failed', call get_build_failure with the id to fetch error details. "+
+				"Returns empty id when no build has ever run."),
+		),
+		w.handleGetBuildStatus,
+	)
+
+	// Tool: get_build_info — slim default for "is my work in the queue?".
+	// Returns the current build (with labels/contributions for verifying coalesced
+	// work) plus counts. Drops accumulated_features and recent_builds — those
+	// live behind get_build_history.
 	w.mcp.AddTool(
 		mcp.NewTool("get_build_info",
-			mcp.WithDescription("Get current build metadata, feature history, and recent build records. "+
-				"Use this to determine if a rebuild is needed based on accumulated features."),
+			mcp.WithDescription("Get the current build with its labels and contributions, "+
+				"plus aggregate counts. Use this to verify your rebuild label landed in a "+
+				"coalesced build. For full history, call get_build_history. For polling, "+
+				"call get_build_status (cheaper)."),
 		),
 		w.handleGetBuildInfo,
+	)
+
+	// Tool: get_build_history — opt-in audit trail.
+	w.mcp.AddTool(
+		mcp.NewTool("get_build_history",
+			mcp.WithDescription("Full build history and accumulated features across all builds. "+
+				"Opt-in because the response grows with project lifetime — use sparingly. "+
+				"Prefer get_build_info for typical 'what's the state?' queries."),
+			mcp.WithNumber("limit",
+				mcp.Description("Max number of recent builds to return (default 10, max 50)")),
+		),
+		w.handleGetBuildHistory,
+	)
+
+	// Tool: get_build_failure — read error lines from build.log on disk.
+	w.mcp.AddTool(
+		mcp.NewTool("get_build_failure",
+			mcp.WithDescription("Fetch error details for a failed build by ID. "+
+				"Reads ~/.ue5/logs/<hash>/build.log and extracts lines containing "+
+				"'error:' / 'Error:' / 'Fatal error:' with surrounding context. "+
+				"Bounded response — safe to call after get_build_status reports failed."),
+			mcp.WithString("build_id",
+				mcp.Description("Build ID to fetch failure for. Defaults to the current build.")),
+		),
+		w.handleGetBuildFailure,
+	)
+
+	// Tool: start_editor — launch the UE5 Editor for a project via the daemon.
+	w.mcp.AddTool(
+		mcp.NewTool("start_editor",
+			mcp.WithDescription("Start the Unreal Engine editor for a project. "+
+				"The daemon manages the process and captures all logs. "+
+				"If project_path is omitted, pass your current working directory — "+
+				"the daemon walks up the directory tree to find a .uproject file. "+
+				"engine_path is auto-resolved from the .uproject's EngineAssociation if omitted."),
+			mcp.WithString("project_path",
+				mcp.Description("Path to the .uproject file, OR a directory under the project. "+
+					"Defaults to caller's cwd if omitted (must be passed by the agent).")),
+			mcp.WithString("engine_path",
+				mcp.Description("Path to the Unreal Engine installation. Auto-resolved if omitted.")),
+		),
+		w.handleStartEditor,
+	)
+
+	// Tool: stop_editor — stop a managed editor instance.
+	w.mcp.AddTool(
+		mcp.NewTool("stop_editor",
+			mcp.WithDescription("Stop the running editor for a project. "+
+				"Use force=true to send SIGKILL instead of a graceful shutdown."),
+			mcp.WithString("project_path", mcp.Required(),
+				mcp.Description("Absolute path to the .uproject file (must match a running instance)")),
+			mcp.WithBoolean("force",
+				mcp.Description("Force-kill instead of graceful shutdown (default false)")),
+		),
+		w.handleStopEditor,
+	)
+
+	// Tool: list_instances — list managed editor instances.
+	w.mcp.AddTool(
+		mcp.NewTool("list_instances",
+			mcp.WithDescription("List all editor instances managed by the daemon, including "+
+				"PID, state (starting/running/stopping/stopped/crashed), and log file path."),
+		),
+		w.handleListInstances,
 	)
 }
 
@@ -261,16 +347,255 @@ func (w *mcpServerWrapper) handleUnregisterAgent(ctx context.Context, req mcp.Ca
 	return mcp.NewToolResultText(fmt.Sprintf(`{"unregistered":"%s"}`, id)), nil
 }
 
+// slimBuildInfo is the agent-facing shape of get_build_info — trimmed from
+// the rich socket-protocol BuildInfoResponse to keep typical polls cheap.
+// CurrentBuild is preserved (not slimmed further) because its Labels and
+// Contributions are how an agent verifies its rebuild request landed in a
+// coalesced build.
+type slimBuildInfo struct {
+	CurrentBuild *BuildRecord `json:"current_build,omitempty"`
+	TotalBuilds  int          `json:"total_builds"`
+	FeatureCount int          `json:"feature_count"`
+}
+
 func (w *mcpServerWrapper) handleGetBuildInfo(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	info := &BuildInfoResponse{
-		CurrentBuild:        w.daemon.state.GetCurrentBuild(),
-		AccumulatedFeatures: w.daemon.state.GetAccumulatedFeatures(),
-		TotalBuilds:         len(w.daemon.state.GetState().BuildHistory),
-		RecentBuilds:        w.daemon.state.GetBuildHistory(10),
+	info := slimBuildInfo{
+		CurrentBuild: w.daemon.state.GetCurrentBuild(),
+		TotalBuilds:  len(w.daemon.state.GetState().BuildHistory),
+		FeatureCount: len(w.daemon.state.GetAccumulatedFeatures()),
 	}
 
 	data, _ := json.MarshalIndent(info, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
+}
+
+// handleGetBuildStatus returns the minimal {id, prompt, status} polling shape.
+// Joins coalesced labels with " + " so the prompt reads naturally.
+func (w *mcpServerWrapper) handleGetBuildStatus(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	current := w.daemon.state.GetCurrentBuild()
+	resp := BuildStatusResponse{}
+	if current != nil {
+		resp.ID = current.ID
+		resp.Status = current.Status
+		resp.Prompt = strings.Join(current.Labels, " + ")
+	}
+	data, _ := json.Marshal(resp) // no indent — every byte counts on this path
+	return mcp.NewToolResultText(string(data)), nil
+}
+
+// handleGetBuildHistory returns the full audit trail. Capped at 50 to bound
+// the response even when an agent passes a large limit.
+func (w *mcpServerWrapper) handleGetBuildHistory(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	limit := req.GetInt("limit", 10)
+	if limit <= 0 {
+		limit = 10
+	}
+	if limit > 50 {
+		limit = 50
+	}
+	resp := BuildHistoryResponse{
+		Builds:              w.daemon.state.GetBuildHistory(limit),
+		AccumulatedFeatures: w.daemon.state.GetAccumulatedFeatures(),
+		TotalBuilds:         len(w.daemon.state.GetState().BuildHistory),
+	}
+	data, _ := json.MarshalIndent(resp, "", "  ")
+	return mcp.NewToolResultText(string(data)), nil
+}
+
+// handleGetBuildFailure extracts error context from the build log on disk.
+// Returns up to maxErrorLines lines, each error line plus ±contextLines around
+// it, deduplicated. Bounded response even on multi-thousand-line build logs.
+func (w *mcpServerWrapper) handleGetBuildFailure(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	buildID := req.GetString("build_id", "")
+
+	// Locate the target build record.
+	var target *BuildRecord
+	if buildID == "" {
+		target = w.daemon.state.GetCurrentBuild()
+	} else {
+		for _, b := range w.daemon.state.GetState().BuildHistory {
+			if b.ID == buildID {
+				rec := b
+				target = &rec
+				break
+			}
+		}
+	}
+	if target == nil {
+		return mcp.NewToolResultError(fmt.Sprintf("no build found with id %q", buildID)), nil
+	}
+
+	logPath := BuildLogFile(target.ProjectPath)
+	resp := BuildFailureResponse{
+		BuildID: target.ID,
+		Error:   target.Error,
+		LogPath: logPath,
+	}
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		// Log doesn't exist — return what we have from the build record.
+		resp.ErrorLines = []string{}
+		out, _ := json.MarshalIndent(resp, "", "  ")
+		return mcp.NewToolResultText(string(out)), nil
+	}
+
+	resp.ErrorLines = extractBuildErrors(string(data), 3, 50)
+	out, _ := json.MarshalIndent(resp, "", "  ")
+	return mcp.NewToolResultText(string(out)), nil
+}
+
+// extractBuildErrors finds lines containing error markers and returns each
+// with ±contextLines neighbors, capped at maxLines total. Markers are matched
+// case-insensitively against common UBT/MSBuild/clang patterns.
+func extractBuildErrors(logContent string, contextLines, maxLines int) []string {
+	lines := strings.Split(logContent, "\n")
+	markers := []string{"error:", "fatal error:", "error c", "error :", "undefined reference", "ld: error"}
+
+	included := make(map[int]bool)
+	for i, line := range lines {
+		lower := strings.ToLower(line)
+		for _, m := range markers {
+			if strings.Contains(lower, m) {
+				start := i - contextLines
+				if start < 0 {
+					start = 0
+				}
+				end := i + contextLines
+				if end >= len(lines) {
+					end = len(lines) - 1
+				}
+				for j := start; j <= end; j++ {
+					included[j] = true
+				}
+				break
+			}
+		}
+	}
+
+	if len(included) == 0 {
+		return []string{}
+	}
+
+	// Emit in order, capped at maxLines.
+	out := make([]string, 0, len(included))
+	for i := 0; i < len(lines); i++ {
+		if included[i] {
+			out = append(out, lines[i])
+			if len(out) >= maxLines {
+				out = append(out, fmt.Sprintf("... (truncated, %d more error-context lines available in %s)", len(included)-len(out), "log file"))
+				return out
+			}
+		}
+	}
+	return out
+}
+
+// handleStartEditor wraps the daemon's instance manager.
+// project_path is optional — the agent should pass its cwd if it doesn't know
+// the .uproject path. We resolve either to a .uproject by walking up.
+func (w *mcpServerWrapper) handleStartEditor(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	rawPath := req.GetString("project_path", "")
+	if rawPath == "" {
+		return mcp.NewToolResultError("project_path is required — pass your current working directory if you don't know the .uproject path"), nil
+	}
+
+	uprojectPath, err := resolveUprojectPath(rawPath)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	enginePath := req.GetString("engine_path", "")
+	if enginePath == "" {
+		uproject, uErr := pkg.NewUprojectE(uprojectPath)
+		if uErr == nil && uproject.EngineAssociation != "" {
+			enginePath = pkg.GetEnginePath(uproject.EngineAssociation)
+		}
+		if enginePath == "" {
+			return mcp.NewToolResultError("engine_path could not be auto-resolved from .uproject; pass it explicitly"), nil
+		}
+	}
+
+	info, err := w.daemon.manager.StartEditor(&StartEditorRequest{
+		ProjectPath: uprojectPath,
+		EnginePath:  enginePath,
+	})
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	data, _ := json.MarshalIndent(info, "", "  ")
+	return mcp.NewToolResultText(string(data)), nil
+}
+
+// handleStopEditor stops a managed editor instance.
+func (w *mcpServerWrapper) handleStopEditor(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	projectPath := req.GetString("project_path", "")
+	if projectPath == "" {
+		return mcp.NewToolResultError("project_path is required"), nil
+	}
+	force := req.GetBool("force", false)
+
+	info, err := w.daemon.manager.StopEditor(projectPath, force)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	data, _ := json.MarshalIndent(info, "", "  ")
+	return mcp.NewToolResultText(string(data)), nil
+}
+
+// handleListInstances lists all editor instances managed by the daemon.
+func (w *mcpServerWrapper) handleListInstances(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	instances := w.daemon.manager.ListInstances()
+	data, _ := json.MarshalIndent(map[string]interface{}{
+		"instances": instances,
+		"count":     len(instances),
+	}, "", "  ")
+	return mcp.NewToolResultText(string(data)), nil
+}
+
+// resolveUprojectPath accepts either a .uproject path or a directory and
+// returns the absolute .uproject path. Mirrors UpdateProjectPath() in
+// cmd/root.go: walks up from the given path until it finds a .uproject file.
+func resolveUprojectPath(rawPath string) (string, error) {
+	abs, err := filepath.Abs(rawPath)
+	if err != nil {
+		return "", fmt.Errorf("invalid path %q: %w", rawPath, err)
+	}
+
+	// If it's already a .uproject file, verify and return.
+	if strings.HasSuffix(strings.ToLower(abs), ".uproject") {
+		if _, err := os.Stat(abs); err != nil {
+			return "", fmt.Errorf(".uproject not found at %s: %w", abs, err)
+		}
+		return abs, nil
+	}
+
+	// Otherwise, treat as a directory and walk up.
+	stat, err := os.Stat(abs)
+	if err != nil {
+		return "", fmt.Errorf("path not found: %s", abs)
+	}
+	dir := abs
+	if !stat.IsDir() {
+		dir = filepath.Dir(abs)
+	}
+
+	for {
+		entries, err := os.ReadDir(dir)
+		if err == nil {
+			for _, e := range entries {
+				if !e.IsDir() && strings.HasSuffix(strings.ToLower(e.Name()), ".uproject") {
+					return filepath.Join(dir, e.Name()), nil
+				}
+			}
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("no .uproject found at or above %s", abs)
+		}
+		dir = parent
+	}
 }
 
 // --- Resource Handlers ---

--- a/pkg/server/protocol.go
+++ b/pkg/server/protocol.go
@@ -138,12 +138,48 @@ type UnregisterAgentRequest struct {
 	ID string `json:"id"`
 }
 
-// BuildInfoResponse is returned for get_build_info requests.
+// BuildInfoResponse is the rich response returned over the daemon socket
+// protocol (CLI consumption). The MCP server composes a slimmer response
+// inline — see mcpserver.go handleGetBuildInfo for the agent-facing shape,
+// which trims AccumulatedFeatures and RecentBuilds to keep polling cheap.
 type BuildInfoResponse struct {
-	CurrentBuild        *BuildRecord `json:"current_build,omitempty"`
-	AccumulatedFeatures []string     `json:"accumulated_features"`
-	TotalBuilds         int          `json:"total_builds"`
+	CurrentBuild        *BuildRecord  `json:"current_build,omitempty"`
+	AccumulatedFeatures []string      `json:"accumulated_features"`
+	TotalBuilds         int           `json:"total_builds"`
 	RecentBuilds        []BuildRecord `json:"recent_builds"`
+}
+
+// BuildStatusResponse is the minimal polling response.
+//
+// Three fields, by design:
+//   - ID: handle the agent uses to query failure details via get_build_failure
+//   - Prompt: the human-readable label(s) supplied at rebuild time, joined for
+//     coalesced builds (e.g. "Added jump + Fixed damage"). Lets agents tell
+//     "is my work in this build?" without paging through Labels/Contributions.
+//   - Status: succeeded / failed / building / pending — the only thing a
+//     polling loop needs to branch on.
+//
+// When no build has ever run, all fields are zero-valued and the agent can
+// detect "no build yet" via ID == "".
+type BuildStatusResponse struct {
+	ID     string      `json:"id"`
+	Prompt string      `json:"prompt"`
+	Status BuildStatus `json:"status"`
+}
+
+// BuildHistoryResponse is returned for get_build_history requests (opt-in).
+type BuildHistoryResponse struct {
+	Builds              []BuildRecord `json:"builds"`
+	AccumulatedFeatures []string      `json:"accumulated_features"`
+	TotalBuilds         int           `json:"total_builds"`
+}
+
+// BuildFailureResponse is returned for get_build_failure requests.
+type BuildFailureResponse struct {
+	BuildID    string   `json:"build_id"`
+	Error      string   `json:"error,omitempty"`
+	ErrorLines []string `json:"error_lines"`
+	LogPath    string   `json:"log_path"`
 }
 
 // Response is the envelope for all server-to-client messages.

--- a/plugin/agents/ue5-dev-assistant.md
+++ b/plugin/agents/ue5-dev-assistant.md
@@ -47,19 +47,64 @@ tools:
   - Bash
 ---
 
-You are a specialized Unreal Engine 5 development assistant focused on managing the build-test-debug cycle during active feature development. You use the `ue5 server` daemon's build orchestrator to manage rebuilds and query captured logs.
+You are a specialized Unreal Engine 5 development assistant focused on managing the build-test-debug cycle during active feature development. You use the `ue5 server` daemon's build orchestrator and MCP tools to manage rebuilds, run the editor, and query captured logs.
 
 **Your Core Responsibilities:**
 
-1. **Build Cycle Management**: Trigger rebuilds via the daemon's build orchestrator with descriptive labels
-2. **Build Metadata Awareness**: Check accumulated features to understand what's in the current build
-3. **Log Analysis**: Query captured logs with filtering by level, category, and pattern
-4. **Error Diagnosis**: Correlate errors with code changes and provide actionable fixes
-5. **Crash Investigation**: Analyze captured log output to determine root causes
+1. **Editor Lifecycle**: Start, stop, and list editor instances via MCP tools
+2. **Build Cycle Management**: Trigger rebuilds via the daemon's build orchestrator with descriptive labels
+3. **Build Metadata Awareness**: Check accumulated features to understand what's in the current build
+4. **Log Analysis**: Query captured logs with filtering by level, category, and pattern
+5. **Error Diagnosis**: Correlate errors with code changes and provide actionable fixes
+6. **Crash Investigation**: Analyze captured log output to determine root causes
 
-**Development Workflow:**
+---
 
-When the user wants to test changes:
+## MCP Tools (preferred over CLI)
+
+The `ue5-server` MCP server exposes these tools. Use them in preference to the CLI when an MCP server is connected — they're cheaper (no shell overhead) and structured.
+
+### Editor lifecycle
+
+| Tool | When to use |
+|---|---|
+| `start_editor` | Launch the UE5 editor for a project. Pass your **current working directory** as `project_path` if you don't know the .uproject path — the daemon walks up to find it. `engine_path` is auto-resolved. |
+| `stop_editor` | Stop a running editor. Pass `force: true` only if graceful shutdown hangs. |
+| `list_instances` | See what editors are currently running. Always check this before starting one. |
+
+**Starting the editor — typical flow:**
+```
+1. list_instances        — is the editor already running for this project?
+2. If not: start_editor with project_path = <your cwd>
+3. Wait, then list_instances again to confirm state == "running"
+```
+
+### Build status — choose the right tool to avoid token bloat
+
+These four tools answer different questions. Picking the wrong one wastes tokens on every poll.
+
+| Tool | Use for | Cost |
+|---|---|---|
+| `get_build_status` | "Is the build done? Did it succeed?" — for polling loops | tiny (~100 B) |
+| `get_build_info` | "Did my rebuild label land in the queue (possibly coalesced)?" | small (~500 B) |
+| `get_build_history` | "Show me the full audit trail / accumulated features" | unbounded — opt-in only |
+| `get_build_failure` | "The build failed — give me the error lines" — call only after status == failed | bounded (~50 lines from build.log) |
+
+**Polling pattern (don't burn tokens):**
+```
+1. Trigger rebuild with `rebuild` tool
+2. Loop: call `get_build_status` every few seconds
+3. When status == "succeeded": stop, report features
+4. When status == "failed": call `get_build_failure` with the id, analyze, suggest fix
+```
+
+NEVER poll `get_build_info` or `get_build_history` in a loop. They were designed for one-off introspection, not status checks.
+
+---
+
+## CLI Fallback
+
+When MCP isn't available (or for human-readable output), use the CLI:
 
 1. **Check Current Build State**: Understand what's already built
    ```bash
@@ -77,12 +122,7 @@ When the user wants to test changes:
    - The daemon handles stop→build→restart atomically (full mode)
    - If another agent is building, request is queued and coalesced automatically
 
-3. **Check Build Result**:
-   ```bash
-   ue5 server build-info --json
-   ```
-   - If succeeded: report success and new accumulated features
-   - If failed: analyze errors
+3. **Check Build Result**: Same as above, or via MCP `get_build_status`.
 
 4. **Monitor Logs**: Query captured logs for errors
    ```bash
@@ -109,6 +149,7 @@ When the user wants to test changes:
 4. **Search for patterns**: `ue5 server logs --pattern "MyClass" --lines 200`
 5. **Recent logs only**: `ue5 server logs --since 5m --lines 200`
 6. **Correlate with code**: Match file paths and line numbers in errors to source files
+7. **Read raw build log on disk** (fallback if daemon is unresponsive): `~/.ue5/logs/<hash>/build.log` where `<hash>` is the first 12 hex chars of SHA-256 of the `.uproject` path. Use `Read` tool to inspect directly.
 
 **Error Pattern Recognition:**
 
@@ -137,11 +178,14 @@ After each operation, report:
 
 **Quality Standards:**
 
-- Always use `ue5 server rebuild` for builds (never manual `kill && build && run`)
-- Always provide a descriptive `--label` summarizing what changed
-- Use `ue5 server build-info --json` to check what's already built before rebuilding
-- Use `ue5 server status --json` to check state before operations
-- Don't start editor manually if build failed (daemon handles this)
+- Always use `ue5 server rebuild` (CLI) or the `rebuild` MCP tool for builds — never manual `kill && build && run`
+- Always provide a descriptive `--label` (or `label:` MCP arg) summarizing what changed
+- Use `get_build_info` (MCP) or `ue5 server build-info --json` to check what's built before rebuilding
+- Use `list_instances` (MCP) or `ue5 server status --json` to check editor state before operations
+- Use `start_editor` (MCP) or `ue5 server run` to launch the editor — pass cwd as `project_path` when in doubt
+- A failed `full`-mode rebuild leaves the editor stopped; investigate via `get_build_failure` before restarting
+- Prefer MCP tools over CLI when both are available — fewer tokens, structured responses
+- For polling, ALWAYS use `get_build_status` (not `get_build_info`) to keep token cost flat
 - Report all errors clearly with file/line references
 - Suggest specific fixes, not generic advice
-- Use `--json` flag when parsing output programmatically
+- Use `--json` flag when parsing CLI output programmatically

--- a/plugin/commands/logs.md
+++ b/plugin/commands/logs.md
@@ -70,6 +70,18 @@ ue5 server logs --lines 0
 3. If errors found, correlate with code using file paths and line numbers in the output
 4. Provide a summary of findings to the user
 
+## On-Disk Log Locations
+
+If the daemon isn't running or you need raw log files, they live under `~/.ue5/logs/<hash>/` where `<hash>` is the first 12 hex chars of `SHA-256(project_path)`:
+
+- **Editor log**: `~/.ue5/logs/<hash>/editor.log` — captured editor stdout/stderr
+- **Build log**: `~/.ue5/logs/<hash>/build.log` — raw UBT compiler output (compile errors, linker failures)
+
+To read a log file directly when the daemon is down:
+```bash
+cat ~/.ue5/logs/$(echo -n "/path/to/YourProject.uproject" | shasum -a 256 | cut -c1-12)/build.log
+```
+
 ## Important Notes
 
 - Logs are only captured for editor instances started via `ue5 server run` or `/uem:start`


### PR DESCRIPTION
## Summary

Splits the bloated `get_build_info` MCP tool into four purpose-built tools to fix the "returns everything ever" anti-pattern that was causing polling agents to burn ~30 KB per call. Also adds the missing editor-lifecycle MCP tools (`start_editor`/`stop_editor`/`list_instances`) so agents can launch the editor directly instead of relying on side effects of full-mode rebuilds.

### The token-economics fix

`get_build_info` previously returned the entire `accumulated_features` history (unbounded — grows monotonically across the project's lifetime) on every call, plus the last 10 full `BuildRecord`s. Polling agents paid this on every status check.

Replaced with four tools chosen by the question being asked:

| Tool | Returns | Use for |
|---|---|---|
| `get_build_status` | `{id, prompt, status}` | polling loops (~80 B/call) |
| `get_build_info` | `{current_build, total_builds, feature_count}` | "is my work in the queue?" |
| `get_build_history` | full history + accumulated_features (capped at 50) | opt-in audit |
| `get_build_failure` | error lines extracted from `build.log` | only after status == failed |

`get_build_failure` reads `~/.ue5/logs/<hash>/build.log` directly, scans for `error:` / `Fatal error:` / `undefined reference` / `ld: error` markers, and returns each match with +/-3 context lines, capped at 50 lines total. No new persistence — uses logs that already exist on disk.

The CLI socket-protocol `BuildInfoResponse` stayed rich (no breaking change for `ue5 server build-info`); MCP composes its slim shape inline via `slimBuildInfo`.

### Editor lifecycle tools

The daemon already supported `start_editor`/`stop_editor`/`list_instances` over its socket protocol, but those weren't exposed via MCP. Agents had no way to launch the editor without a full-mode rebuild side effect. Now they do.

`start_editor` accepts either a `.uproject` path or any directory, walking up to find the project — same logic as `cmd/root.go`'s `UpdateProjectPath()`. The agent prompt instructs agents to pass their cwd as `project_path` when they don't know the project path, since the MCP server has no access to client cwd.

### Agent prompt overhaul

`ue5-dev-assistant.md` gained an "MCP Tools" section that explicitly documents which build query to use for which question (polling vs introspection vs failure details), plus a new editor-lifecycle workflow. Removed a contradictory "Don't start editor manually" line.

### Also includes

A small docs commit (separate) adding the `~/.ue5/logs/<hash>/` path scheme to the README and the `/uem:logs` slash-command doc, so humans and agents can find raw logs when the daemon is down.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./pkg/server/...` passes
- [ ] Manual: connect a Claude Code session to the daemon's MCP endpoint, confirm new tools are listed
- [ ] Manual: trigger a rebuild, poll `get_build_status` in a loop, confirm response is ~80 B
- [ ] Manual: force a failed build, call `get_build_failure`, confirm extracted error lines match `build.log`
- [ ] Manual: call `start_editor` with `project_path` set to a project subdirectory, confirm the daemon walks up to find the `.uproject`
- [ ] Manual: confirm `ue5 server build-info` CLI still shows the full feature history (no regression on the rich shape)