### PR TITLE
Fix full-rebuild hangs: editor-exit gate, approval deadline, state.json retention caps

### DIFF
--- a/pkg/build.go
+++ b/pkg/build.go
@@ -48,14 +48,16 @@ func RunBuildScriptToWriter(enginePath, target, platform, state, projectPath str
 
 // RunBuildScriptPiped prepares a build command with piped stdout/stderr.
 // The caller is responsible for calling cmd.Start(), reading from the pipes,
-// and calling cmd.Wait().
-func RunBuildScriptPiped(enginePath, target, platform, state, projectPath string) (cmd *exec.Cmd, stdout io.ReadCloser, stderr io.ReadCloser, err error) {
+// and calling cmd.Wait(). extraArgs are passed through Build.sh/Build.bat
+// verbatim to UnrealBuildTool.
+func RunBuildScriptPiped(enginePath, target, platform, state, projectPath string, extraArgs ...string) (cmd *exec.Cmd, stdout io.ReadCloser, stderr io.ReadCloser, err error) {
 	osPath := OsStringSliceSwitcher(WindowsBuildScript, UnixBuildScript, UnixBuildScript)
 	basePath := []string{enginePath}
 	pathElements := append(basePath, osPath...)
 	buildScript := filepath.Join(pathElements...)
 
-	cmd = exec.Command(buildScript, target, platform, state, projectPath)
+	args := append([]string{target, platform, state, projectPath}, extraArgs...)
+	cmd = exec.Command(buildScript, args...)
 
 	stdout, err = cmd.StdoutPipe()
 	if err != nil {

--- a/pkg/server/builder.go
+++ b/pkg/server/builder.go
@@ -119,6 +119,9 @@ func (b *BuildOrchestrator) createRecord(requests []RebuildRequest) *BuildRecord
 		if record.ProjectPath == "" {
 			record.ProjectPath = req.ProjectPath
 		}
+		if record.EnginePath == "" {
+			record.EnginePath = req.EnginePath
+		}
 		if record.Target == "" {
 			record.Target = req.Target
 		}
@@ -194,12 +197,12 @@ func (b *BuildOrchestrator) executeBuild(ctx context.Context, record *BuildRecor
 		Type:      "rebuild_complete",
 		Timestamp: now,
 		Data: map[string]interface{}{
-			"build_id":            record.ID,
-			"status":              string(status),
-			"error":               errMsg,
-			"contributions":       record.Contributions,
+			"build_id":             record.ID,
+			"status":               string(status),
+			"error":                errMsg,
+			"contributions":        record.Contributions,
 			"accumulated_features": b.state.GetAccumulatedFeatures(),
-			"duration":            now.Sub(record.StartedAt).String(),
+			"duration":             now.Sub(record.StartedAt).String(),
 		},
 	})
 
@@ -217,20 +220,20 @@ func (b *BuildOrchestrator) executeBuild(ctx context.Context, record *BuildRecor
 	b.mu.Unlock()
 }
 
-// executeFullRebuild builds first (editor stays running), then stops and restarts
-// only if the build succeeds. This keeps the editor available during compilation
-// and avoids unnecessary downtime on build failures.
+// executeFullRebuild performs a strict stop -> build -> restart cycle.
+//
+// The ordering is load-bearing: UBT decides at startup whether to build in
+// hot-reload mode by checking for live UnrealEditor processes from the same
+// engine. If any editor is alive when UBT starts — tracked, orphaned from a
+// previous daemon, or launched by hand — the build emits
+// libUnrealEditor-<Module>-000N patch binaries instead of relinking the base
+// binaries, the build reports success, and the restarted editor silently runs
+// stale code. The editor must be verifiably exited (process gone, not just
+// signalled) before UBT starts.
 func (b *BuildOrchestrator) executeFullRebuild(ctx context.Context, record *BuildRecord) error {
-	// Step 1: Run the build while the editor stays running
-	buildFn := b.runBuild
-	if b.buildRunner != nil {
-		buildFn = b.buildRunner
-	}
-	if err := buildFn(record); err != nil {
-		return fmt.Errorf("build failed: %w", err)
-	}
+	enginePath := b.resolveEnginePath(record)
 
-	// Step 2: Build succeeded — check with connected agents before stopping editor
+	// Step 1: Check with connected agents before disrupting the editor
 	if b.restartApprover != nil {
 		for {
 			approved, blockers := b.restartApprover(ctx)
@@ -256,47 +259,84 @@ func (b *BuildOrchestrator) executeFullRebuild(ctx context.Context, record *Buil
 		}
 	}
 
-	// Step 3: Stop the editor
-	instances := b.manager.ListInstances()
-	for _, inst := range instances {
+	// Step 2: Stop the tracked editor instance (waits for actual process
+	// exit, force-killing after 10s)
+	for _, inst := range b.manager.ListInstances() {
 		if inst.ProjectPath == record.ProjectPath && (inst.State == StateRunning || inst.State == StateStarting) {
 			log.Info("Stopping editor for rebuild", "project", inst.ProjectName, "pid", inst.PID)
 			if _, err := b.manager.StopEditor(inst.ProjectPath, false); err != nil {
-				log.Warn("Failed to stop editor, continuing with restart", "error", err)
+				log.Warn("Failed to stop editor via instance manager, relying on process gate", "error", err)
 			}
 			break
 		}
 	}
 
-	// Step 4: Restart the editor
-	// Find the engine path from the last known instance, then fall back to .uproject manifest lookup
-	enginePath := ""
-	for _, inst := range instances {
-		if inst.ProjectPath == record.ProjectPath {
-			enginePath = inst.EnginePath
-			break
+	// Step 3: Gate — verify at the process level that NO UnrealEditor from
+	// this engine is still alive (catches orphans the daemon never tracked).
+	// Refuses to start UBT if any editor survives termination.
+	if enginePath != "" {
+		if err := ensureNoEditorProcesses(pkg.EditorBinaryPath(enginePath), record.ProjectPath); err != nil {
+			return fmt.Errorf("refusing to start UBT: %w", err)
 		}
-	}
-	if enginePath == "" {
-		uproject, err := pkg.NewUprojectE(record.ProjectPath)
-		if err == nil && uproject.EngineAssociation != "" {
-			enginePath = pkg.GetEnginePath(uproject.EngineAssociation)
-		}
-	}
-	if enginePath == "" {
-		log.Warn("No engine path found, skipping editor restart")
-		return nil
+	} else {
+		log.Warn("No engine path resolved; skipping editor process gate", "build_id", record.ID)
 	}
 
-	_, err := b.manager.StartEditor(&StartEditorRequest{
+	// Step 4: Delete stale hot-reload patch binaries from earlier incidents
+	// so module manifests can only reference freshly linked base binaries.
+	if removed := cleanHotReloadArtifacts(filepath.Dir(record.ProjectPath)); len(removed) > 0 {
+		log.Warn("Removed stale hot-reload patch binaries", "count", len(removed), "files", removed)
+	}
+
+	// Step 5: Run the build with no editor alive
+	buildFn := b.runBuild
+	if b.buildRunner != nil {
+		buildFn = b.buildRunner
+	}
+	buildErr := buildFn(record)
+
+	// Step 6: Restart the editor. On build failure the previous binaries are
+	// still intact, so restarting keeps the machine usable either way.
+	if enginePath == "" {
+		log.Warn("No engine path found, skipping editor restart")
+		if buildErr != nil {
+			return fmt.Errorf("build failed: %w", buildErr)
+		}
+		return nil
+	}
+	if _, err := b.manager.StartEditor(&StartEditorRequest{
 		ProjectPath: record.ProjectPath,
 		EnginePath:  enginePath,
-	})
-	if err != nil {
+	}); err != nil {
+		if buildErr != nil {
+			return fmt.Errorf("build failed: %w (editor restart also failed: %v)", buildErr, err)
+		}
 		return fmt.Errorf("editor restart failed: %w", err)
 	}
 
+	if buildErr != nil {
+		return fmt.Errorf("build failed: %w", buildErr)
+	}
 	return nil
+}
+
+// resolveEnginePath finds the engine for a build: a tracked instance's engine
+// first, then the engine_path carried on the rebuild request, then the
+// .uproject's engine association manifest lookup.
+func (b *BuildOrchestrator) resolveEnginePath(record *BuildRecord) string {
+	for _, inst := range b.manager.ListInstances() {
+		if inst.ProjectPath == record.ProjectPath && inst.EnginePath != "" {
+			return inst.EnginePath
+		}
+	}
+	if record.EnginePath != "" {
+		return record.EnginePath
+	}
+	uproject, err := pkg.NewUprojectE(record.ProjectPath)
+	if err == nil && uproject.EngineAssociation != "" {
+		return pkg.GetEnginePath(uproject.EngineAssociation)
+	}
+	return ""
 }
 
 // executeHotReload builds in the background while the editor stays running.
@@ -317,21 +357,7 @@ func (b *BuildOrchestrator) runBuild(record *BuildRecord) error {
 
 	log.Info("Running UBT build", "target", record.Target, "platform", record.Platform, "config", record.Configuration, "log", logPath)
 
-	// Resolve engine path
-	enginePath := ""
-	instances := b.manager.ListInstances()
-	for _, inst := range instances {
-		if inst.ProjectPath == record.ProjectPath {
-			enginePath = inst.EnginePath
-			break
-		}
-	}
-	if enginePath == "" {
-		uproject, err := pkg.NewUprojectE(record.ProjectPath)
-		if err == nil && uproject.EngineAssociation != "" {
-			enginePath = pkg.GetEnginePath(uproject.EngineAssociation)
-		}
-	}
+	enginePath := b.resolveEnginePath(record)
 	if enginePath == "" {
 		return fmt.Errorf("cannot determine engine path for project: %s", record.ProjectPath)
 	}
@@ -344,6 +370,14 @@ func (b *BuildOrchestrator) runBuild(record *BuildRecord) error {
 	b.setBuildCapture(capture)
 	defer b.clearBuildCapture()
 
+	// Full builds must never produce hot-reload patch binaries, even if an
+	// editor slips in between the process gate and UBT startup — the flag
+	// forces UBT to link base binaries regardless of editor detection.
+	var extraArgs []string
+	if record.Mode == BuildModeFull {
+		extraArgs = append(extraArgs, "-NoHotReloadFromIDE")
+	}
+
 	// Get piped command
 	cmd, stdout, stderr, err := pkg.RunBuildScriptPiped(
 		enginePath,
@@ -351,6 +385,7 @@ func (b *BuildOrchestrator) runBuild(record *BuildRecord) error {
 		record.Platform,
 		record.Configuration,
 		record.ProjectPath,
+		extraArgs...,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create build command: %w", err)

--- a/pkg/server/builder.go
+++ b/pkg/server/builder.go
@@ -12,28 +12,42 @@ import (
 	"github.com/charmbracelet/log"
 )
 
+const (
+	// defaultApprovalRetryInterval is how long to wait between restart
+	// approval rounds while agents report busy.
+	defaultApprovalRetryInterval = 5 * time.Second
+	// defaultApprovalTimeout bounds the total time spent waiting for agent
+	// approval. Once exceeded the build proceeds anyway — a client that
+	// cannot or will not answer must not hold full rebuilds hostage.
+	defaultApprovalTimeout = 2 * time.Minute
+)
+
 // BuildOrchestrator manages the build lifecycle with coalescing support.
 type BuildOrchestrator struct {
-	manager         *InstanceManager
-	state           *StateStore
-	agents          *AgentRegistry
-	mcpServer       *mcpServerWrapper
-	restartApprover func(ctx context.Context) (bool, []string)
-	buildRunner     func(record *BuildRecord) error // defaults to runBuild; overridable for testing
-	mu              sync.Mutex
-	building        bool
-	queue           []RebuildRequest
-	buildCapture    *LogCapture
-	buildCaptureMu  sync.RWMutex
+	manager               *InstanceManager
+	state                 *StateStore
+	agents                *AgentRegistry
+	mcpServer             *mcpServerWrapper
+	restartApprover       func(ctx context.Context) (bool, []string)
+	buildRunner           func(record *BuildRecord) error // defaults to runBuild; overridable for testing
+	approvalRetryInterval time.Duration
+	approvalTimeout       time.Duration
+	mu                    sync.Mutex
+	building              bool
+	queue                 []RebuildRequest
+	buildCapture          *LogCapture
+	buildCaptureMu        sync.RWMutex
 }
 
 // NewBuildOrchestrator creates a new build orchestrator.
 func NewBuildOrchestrator(manager *InstanceManager, state *StateStore, agents *AgentRegistry) *BuildOrchestrator {
 	return &BuildOrchestrator{
-		manager: manager,
-		state:   state,
-		agents:  agents,
-		queue:   []RebuildRequest{},
+		manager:               manager,
+		state:                 state,
+		agents:                agents,
+		queue:                 []RebuildRequest{},
+		approvalRetryInterval: defaultApprovalRetryInterval,
+		approvalTimeout:       defaultApprovalTimeout,
 	}
 }
 
@@ -233,15 +247,34 @@ func (b *BuildOrchestrator) executeBuild(ctx context.Context, record *BuildRecor
 func (b *BuildOrchestrator) executeFullRebuild(ctx context.Context, record *BuildRecord) error {
 	enginePath := b.resolveEnginePath(record)
 
-	// Step 1: Check with connected agents before disrupting the editor
+	// Step 1: Check with connected agents before disrupting the editor.
+	// Approval is best-effort with a hard deadline: agents that answer "busy"
+	// delay the restart, but a client that cannot or will not answer must not
+	// hold the build hostage forever — past the deadline we log the blockers
+	// loudly and proceed.
 	if b.restartApprover != nil {
+		deadline := time.Now().Add(b.approvalTimeout)
 		for {
 			approved, blockers := b.restartApprover(ctx)
 			if approved {
 				break
 			}
-			log.Info("Restart blocked by agents, retrying in 5s",
-				"build_id", record.ID, "blockers", blockers)
+			if time.Now().After(deadline) {
+				log.Warn("Restart approval deadline exceeded; proceeding with rebuild despite blockers",
+					"build_id", record.ID, "blockers", blockers, "waited", b.approvalTimeout)
+				b.agents.Emit(AgentEvent{
+					Type:      "restart_forced",
+					Timestamp: time.Now(),
+					Data: map[string]interface{}{
+						"build_id":        record.ID,
+						"blocking_agents": blockers,
+						"waited":          b.approvalTimeout.String(),
+					},
+				})
+				break
+			}
+			log.Info("Restart blocked by agents, retrying",
+				"build_id", record.ID, "blockers", blockers, "retry_in", b.approvalRetryInterval)
 			b.agents.Emit(AgentEvent{
 				Type:      "restart_blocked",
 				Timestamp: time.Now(),
@@ -253,7 +286,7 @@ func (b *BuildOrchestrator) executeFullRebuild(ctx context.Context, record *Buil
 			select {
 			case <-ctx.Done():
 				return fmt.Errorf("build cancelled while waiting for agent approval")
-			case <-time.After(5 * time.Second):
+			case <-time.After(b.approvalRetryInterval):
 				// retry
 			}
 		}

--- a/pkg/server/builder_test.go
+++ b/pkg/server/builder_test.go
@@ -277,6 +277,7 @@ func TestFullRebuildEmitsRestartBlocked(t *testing.T) {
 		}
 		return true, nil
 	}
+	b.approvalRetryInterval = 10 * time.Millisecond
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
@@ -305,6 +306,76 @@ func TestFullRebuildEmitsRestartBlocked(t *testing.T) {
 
 	if callCount < 2 {
 		t.Errorf("Expected approver to be called at least twice, got %d", callCount)
+	}
+}
+
+func TestFullRebuildProceedsAfterApprovalDeadline(t *testing.T) {
+	state := NewStateStore()
+	state.path = filepath.Join(t.TempDir(), "state.json")
+	agents := NewAgentRegistry()
+	manager := NewInstanceManager()
+	b := NewBuildOrchestrator(manager, state, agents)
+
+	var events []AgentEvent
+	var mu sync.Mutex
+	agents.SetEventCallback(func(event AgentEvent) {
+		mu.Lock()
+		events = append(events, event)
+		mu.Unlock()
+	})
+
+	buildRan := false
+	b.buildRunner = func(record *BuildRecord) error {
+		buildRan = true
+		return nil
+	}
+
+	// An approver that never approves — e.g. a wedged client that times out
+	// every round. Without a deadline this loops forever.
+	approverCalls := 0
+	b.restartApprover = func(ctx context.Context) (bool, []string) {
+		approverCalls++
+		return false, []string{"session-stuck"}
+	}
+	b.approvalRetryInterval = 10 * time.Millisecond
+	b.approvalTimeout = 50 * time.Millisecond
+
+	record := &BuildRecord{
+		ID:          "test-deadline",
+		ProjectPath: "/fake/project.uproject",
+		Mode:        BuildModeFull,
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- b.executeFullRebuild(context.Background(), record) }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Expected build to proceed after approval deadline, got error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("executeFullRebuild did not return: approval deadline was not enforced")
+	}
+
+	if !buildRan {
+		t.Error("Expected build to run once the approval deadline expired")
+	}
+	if approverCalls < 2 {
+		t.Errorf("Expected approver to be retried before the deadline, got %d call(s)", approverCalls)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	foundForced := false
+	for _, e := range events {
+		if e.Type == "restart_forced" {
+			foundForced = true
+			break
+		}
+	}
+	if !foundForced {
+		t.Error("Expected 'restart_forced' event when proceeding past blockers")
 	}
 }
 

--- a/pkg/server/daemon.go
+++ b/pkg/server/daemon.go
@@ -378,7 +378,7 @@ func (d *Daemon) handleGetBuildInfo(conn net.Conn, req Request) {
 		BuildInfo: &BuildInfoResponse{
 			CurrentBuild:        d.state.GetCurrentBuild(),
 			AccumulatedFeatures: d.state.GetAccumulatedFeatures(),
-			TotalBuilds:         len(d.state.GetState().BuildHistory),
+			TotalBuilds:         d.state.TotalBuilds(),
 			RecentBuilds:        d.state.GetBuildHistory(10),
 		},
 	})

--- a/pkg/server/dashboard.go
+++ b/pkg/server/dashboard.go
@@ -144,7 +144,7 @@ func (ds *dashboardServer) handleBuild(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, BuildInfoResponse{
 		CurrentBuild:        ds.state.GetCurrentBuild(),
 		AccumulatedFeatures: ds.state.GetAccumulatedFeatures(),
-		TotalBuilds:         len(ds.state.GetState().BuildHistory),
+		TotalBuilds:         ds.state.TotalBuilds(),
 		RecentBuilds:        history,
 	})
 }

--- a/pkg/server/editorgate.go
+++ b/pkg/server/editorgate.go
@@ -1,0 +1,221 @@
+package server
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/charmbracelet/log"
+)
+
+// UBT decides at startup whether to build in hot-reload mode by scanning
+// Engine/Intermediate/EditorRuns for live processes whose executable is the
+// engine's UnrealEditor binary (HotReload.cs ShouldDoHotReloadFromIDE). It
+// does NOT check which project those editors have open. If any such editor is
+// alive when UBT starts, the build emits libUnrealEditor-<Module>-000N patch
+// binaries instead of relinking the bases, and a subsequently restarted
+// editor silently runs stale code. The gate below guarantees no such process
+// exists before UBT is allowed to start.
+const (
+	editorExitGrace    = 20 * time.Second // SIGTERM -> SIGKILL escalation point
+	editorExitTimeout  = 45 * time.Second // total budget before refusing to build
+	editorPollInterval = 500 * time.Millisecond
+)
+
+// editorProc is one live UnrealEditor process found on the system.
+type editorProc struct {
+	PID  int
+	Args string
+}
+
+// findEditorProcesses lists live processes whose executable is editorBinary,
+// split into those with projectPath on their command line and all others.
+// Unlike InstanceManager, this sees processes the daemon never spawned
+// (orphans from a previous daemon, manual launches).
+func findEditorProcesses(editorBinary, projectPath string) (project []editorProc, others []editorProc, err error) {
+	if runtime.GOOS == "windows" {
+		// Process sweep is not implemented on Windows; the -NoHotReloadFromIDE
+		// UBT flag still protects full builds there.
+		return nil, nil, nil
+	}
+
+	out, err := exec.Command("ps", "-axww", "-o", "pid=,args=").Output()
+	if err != nil {
+		return nil, nil, fmt.Errorf("ps failed: %w", err)
+	}
+	project, others = parseEditorProcesses(string(out), editorBinary, projectPath)
+	return project, others, nil
+}
+
+// parseEditorProcesses splits `ps -axww -o pid=,args=` output into editor
+// processes for the given project vs. other editors from the same binary.
+func parseEditorProcesses(psOutput, editorBinary, projectPath string) (project []editorProc, others []editorProc) {
+	for _, line := range strings.Split(psOutput, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		fields := strings.SplitN(line, " ", 2)
+		if len(fields) != 2 {
+			continue
+		}
+		pid, err := strconv.Atoi(fields[0])
+		if err != nil {
+			continue
+		}
+		args := strings.TrimSpace(fields[1])
+		// The command must BE the editor binary, not merely mention it
+		// (e.g. a tail/lsof on its path). Prefix match tolerates arguments
+		// after the path; the engine path itself may contain spaces.
+		if !strings.HasPrefix(args, editorBinary) {
+			continue
+		}
+		proc := editorProc{PID: pid, Args: args}
+		if strings.Contains(args, projectPath) {
+			project = append(project, proc)
+		} else {
+			others = append(others, proc)
+		}
+	}
+	return project, others
+}
+
+// ensureNoEditorProcesses blocks until no process running editorBinary
+// remains alive. Editors with projectPath open are terminated: SIGTERM
+// first (graceful editor shutdown, no restore prompt on relaunch), SIGKILL
+// after editorExitGrace. Editors from the same engine with a different
+// project open cannot be killed safely but still flip UBT into hot-reload
+// mode, so their presence is an error. Returns nil only when the system is
+// verifiably clear of editor processes for this engine.
+func ensureNoEditorProcesses(editorBinary, projectPath string) error {
+	deadline := time.Now().Add(editorExitTimeout)
+	killAfter := time.Now().Add(editorExitGrace)
+	signalled := map[int]bool{}
+	sentKill := false
+
+	for {
+		project, others, err := findEditorProcesses(editorBinary, projectPath)
+		if err != nil {
+			return fmt.Errorf("editor process scan failed: %w", err)
+		}
+
+		if len(project) == 0 && len(others) == 0 {
+			if sentKill {
+				// A SIGKILLed editor leaves PackageRestoreData.json behind;
+				// on relaunch it raises a modal "Restore Packages" dialog that
+				// parks the editor before any automation can reach it.
+				quarantinePackageRestoreData(filepath.Dir(projectPath))
+			}
+			return nil
+		}
+
+		if len(project) == 0 && len(others) > 0 {
+			pids := procPIDs(others)
+			return fmt.Errorf("UnrealEditor process(es) %v from the same engine are running a different project; UBT would build hot-reload patch binaries", pids)
+		}
+
+		if time.Now().After(deadline) {
+			return fmt.Errorf("UnrealEditor process(es) %v still alive after %s", procPIDs(project), editorExitTimeout)
+		}
+
+		for _, p := range project {
+			proc, findErr := os.FindProcess(p.PID)
+			if findErr != nil {
+				continue
+			}
+			switch {
+			case time.Now().After(killAfter):
+				log.Warn("Editor did not exit after SIGTERM, sending SIGKILL", "pid", p.PID)
+				_ = proc.Kill()
+				sentKill = true
+			case !signalled[p.PID]:
+				log.Warn("Terminating untracked editor before full build", "pid", p.PID)
+				_ = proc.Signal(syscall.SIGTERM)
+				signalled[p.PID] = true
+			}
+		}
+
+		time.Sleep(editorPollInterval)
+	}
+}
+
+func procPIDs(procs []editorProc) []int {
+	pids := make([]int, 0, len(procs))
+	for _, p := range procs {
+		pids = append(pids, p.PID)
+	}
+	return pids
+}
+
+// quarantinePackageRestoreData renames Saved/Autosaves/PackageRestoreData.json
+// aside (never deletes) so a relaunched editor boots without the modal
+// restore prompt. Real assets are saved per-asset by the MCP save paths; the
+// restore data only covers crash-recovery temps.
+func quarantinePackageRestoreData(projectDir string) {
+	p := filepath.Join(projectDir, "Saved", "Autosaves", "PackageRestoreData.json")
+	if _, err := os.Stat(p); err != nil {
+		return
+	}
+	bak := p + ".quarantined-" + time.Now().Format("20060102-150405")
+	if err := os.Rename(p, bak); err != nil {
+		log.Warn("Failed to quarantine package restore data", "path", p, "error", err)
+		return
+	}
+	log.Warn("Quarantined package restore data left by SIGKILL", "moved_to", bak)
+}
+
+// hotReloadPatchRe matches UBT hot-reload patch binaries: the base module
+// binary name plus a -NNNN numeric suffix (libUnrealEditor-Foo-0001.dylib,
+// UnrealEditor-Foo-1234.dll, and their .patch_N variants are all covered by
+// the numeric-suffix rule).
+var hotReloadPatchRe = regexp.MustCompile(`^(?:lib)?UnrealEditor-.+-\d{4}\.(?:dylib|so|dll|pdb)$`)
+
+// cleanHotReloadArtifacts deletes stale hot-reload patch binaries under the
+// project's Binaries/ and Plugins/ trees so that .modules manifests written
+// by the upcoming build can only reference freshly linked base binaries.
+// Returns the paths removed.
+func cleanHotReloadArtifacts(projectDir string) []string {
+	skipDirs := map[string]bool{
+		"Content":          true,
+		"Intermediate":     true,
+		"Saved":            true,
+		"Source":           true,
+		"Config":           true,
+		"Resources":        true,
+		"Shaders":          true,
+		"DerivedDataCache": true,
+		".git":             true,
+	}
+
+	var removed []string
+	for _, root := range []string{filepath.Join(projectDir, "Binaries"), filepath.Join(projectDir, "Plugins")} {
+		_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return nil
+			}
+			if d.IsDir() {
+				if skipDirs[d.Name()] {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if hotReloadPatchRe.MatchString(d.Name()) {
+				if rmErr := os.Remove(path); rmErr == nil {
+					removed = append(removed, path)
+				} else {
+					log.Warn("Failed to remove hot-reload patch binary", "path", path, "error", rmErr)
+				}
+			}
+			return nil
+		})
+	}
+	return removed
+}

--- a/pkg/server/editorgate_test.go
+++ b/pkg/server/editorgate_test.go
@@ -1,0 +1,117 @@
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const (
+	testEditorBinary = "/Users/Shared/Epic Games/UE_5.8/Engine/Binaries/Mac/UnrealEditor.app/Contents/MacOS/UnrealEditor"
+	testProjectPath  = "/Users/dev/IslandSurvival/IslandSurvival.uproject"
+)
+
+func TestParseEditorProcesses(t *testing.T) {
+	psOutput := `  100 /sbin/launchd
+35450 ` + testEditorBinary + ` ` + testProjectPath + `
+35460 ` + testEditorBinary + ` /Users/dev/OtherGame/OtherGame.uproject
+35470 ` + testEditorBinary + `
+90404 /Users/dev/UnrealEngine/Engine/Binaries/Mac/UnrealEditorServices.app/Contents/MacOS/UnrealEditorServices
+98025 /Applications/Epic Games Launcher.app/Contents/UE/Engine/Binaries/Mac/EpicWebHelper --type=renderer
+50000 tail -f ` + testEditorBinary + `.log
+`
+
+	project, others := parseEditorProcesses(psOutput, testEditorBinary, testProjectPath)
+
+	if len(project) != 1 || project[0].PID != 35450 {
+		t.Errorf("expected exactly project editor PID 35450, got %+v", project)
+	}
+	// 35460 (other project) and 35470 (no project on cmdline) are both
+	// "other" editors; UnrealEditorServices, EpicWebHelper, and the tail
+	// process must not match at all.
+	if len(others) != 2 {
+		t.Fatalf("expected 2 other editors, got %+v", others)
+	}
+	if others[0].PID != 35460 || others[1].PID != 35470 {
+		t.Errorf("unexpected other-editor PIDs: %+v", others)
+	}
+}
+
+func TestParseEditorProcessesEmpty(t *testing.T) {
+	project, others := parseEditorProcesses("  100 /sbin/launchd\n", testEditorBinary, testProjectPath)
+	if len(project) != 0 || len(others) != 0 {
+		t.Errorf("expected no matches, got project=%+v others=%+v", project, others)
+	}
+}
+
+func TestHotReloadPatchRe(t *testing.T) {
+	matches := []string{
+		"libUnrealEditor-SadTire_MCP-0001.dylib",
+		"libUnrealEditor-IslandSurvivalCore-0012.dylib",
+		"UnrealEditor-MyModule-4821.dll",
+		"UnrealEditor-MyModule-4821.pdb",
+	}
+	nonMatches := []string{
+		"libUnrealEditor-SadTire_MCP.dylib",
+		"UnrealEditor-MyModule.dll",
+		"UnrealEditor.modules",
+		"libUnrealEditor-Foo-001.dylib", // 3 digits: not a patch suffix
+		"libSomeOtherLib-0001.dylib",    // not an UnrealEditor module
+		"libUnrealEditor-Foo-0001.dylib.bak",
+	}
+	for _, name := range matches {
+		if !hotReloadPatchRe.MatchString(name) {
+			t.Errorf("expected %q to match", name)
+		}
+	}
+	for _, name := range nonMatches {
+		if hotReloadPatchRe.MatchString(name) {
+			t.Errorf("expected %q NOT to match", name)
+		}
+	}
+}
+
+func TestCleanHotReloadArtifacts(t *testing.T) {
+	projectDir := t.TempDir()
+
+	write := func(rel string) string {
+		p := filepath.Join(projectDir, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte("x"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	patch1 := write("Binaries/Mac/libUnrealEditor-Game-0001.dylib")
+	patch2 := write("Plugins/SadTirePlugins/SadTire_MCP/Binaries/Mac/libUnrealEditor-SadTire_MCP-0003.dylib")
+	base := write("Plugins/SadTirePlugins/SadTire_MCP/Binaries/Mac/libUnrealEditor-SadTire_MCP.dylib")
+	// A pruned directory must never be touched, even with a matching name.
+	prunedDecoy := write("Plugins/SadTirePlugins/SadTire_MCP/Content/libUnrealEditor-Decoy-0001.dylib")
+
+	removed := cleanHotReloadArtifacts(projectDir)
+
+	if len(removed) != 2 {
+		t.Fatalf("expected 2 removals, got %v", removed)
+	}
+	for _, gone := range []string{patch1, patch2} {
+		if _, err := os.Stat(gone); !os.IsNotExist(err) {
+			t.Errorf("expected %s to be removed", gone)
+		}
+	}
+	for _, kept := range []string{base, prunedDecoy} {
+		if _, err := os.Stat(kept); err != nil {
+			t.Errorf("expected %s to survive: %v", kept, err)
+		}
+	}
+}
+
+func TestEnsureNoEditorProcessesCleanSystem(t *testing.T) {
+	// No editor binary at this fake path can be running; the gate must pass
+	// immediately without signalling anything.
+	if err := ensureNoEditorProcesses("/nonexistent/FakeEngine/UnrealEditor", testProjectPath); err != nil {
+		t.Errorf("expected clean pass, got %v", err)
+	}
+}

--- a/pkg/server/mcpserver.go
+++ b/pkg/server/mcpserver.go
@@ -119,7 +119,10 @@ func (w *mcpServerWrapper) BroadcastEvent(event AgentEvent) {
 // RequestRestartApproval asks all connected MCP clients whether they are okay
 // with an editor restart. Returns true if all agents approve (or if no agents
 // are connected). Returns false with a list of blocking session IDs if any
-// agent is busy or fails to respond.
+// agent answers busy, gives an ambiguous answer, or fails transiently
+// (e.g. times out). Sessions that are incapable of answering — no sampling
+// support, no server in the session context — do not block: they haven't
+// objected, and retrying them can never produce an answer.
 func (w *mcpServerWrapper) RequestRestartApproval(ctx context.Context) (approved bool, blockingAgents []string) {
 	w.sessionsMu.RLock()
 	if len(w.sessions) == 0 {
@@ -180,12 +183,24 @@ func (w *mcpServerWrapper) RequestRestartApproval(ctx context.Context) (approved
 
 			mcpSrv := mcpserver.ServerFromContext(e.ctx)
 			if mcpSrv == nil {
-				results <- result{sessionID: e.id, busy: true}
+				// No MCP server bound to this session's context: the daemon
+				// can never deliver a sampling request here, so the session
+				// can never answer. Not an objection — don't block on it.
+				log.Debug("Session context has no MCP server; not blocking restart", "session", e.id)
+				results <- result{sessionID: e.id, busy: false}
 				return
 			}
 
 			resp, err := mcpSrv.RequestSampling(samplingCtx, samplingReq)
 			if err != nil {
+				if isSamplingUnsupported(err) {
+					// The client is incapable of answering sampling requests;
+					// retrying can never change that. Only an explicit "yes
+					// I'm busy" answer should block a restart.
+					log.Debug("Client cannot answer sampling requests; not blocking restart", "session", e.id, "error", err)
+					results <- result{sessionID: e.id, busy: false}
+					return
+				}
 				log.Debug("Sampling request failed, treating as busy", "session", e.id, "error", err)
 				results <- result{sessionID: e.id, busy: true}
 				return
@@ -203,6 +218,33 @@ func (w *mcpServerWrapper) RequestRestartApproval(ctx context.Context) (approved
 	}
 
 	return len(blockingAgents) == 0, blockingAgents
+}
+
+// samplingUnsupportedPatterns match errors meaning the client can never
+// answer a sampling request — as opposed to transient failures (timeouts,
+// broken pipes) where the client might genuinely be busy. Notably, mcp-go's
+// SSE sessions do not implement SessionWithSampling at all, so every SSE
+// client hits "session does not support sampling".
+var samplingUnsupportedPatterns = []string{
+	"session does not support sampling", // mcp-go: transport lacks SessionWithSampling
+	"no active session",                 // mcp-go: no client session bound to context
+	"method not found",                  // JSON-RPC -32601 from a client without sampling
+	"not supported",                     // generic client-side rejection
+}
+
+// isSamplingUnsupported reports whether err indicates the client is incapable
+// of answering sampling requests, so it should not block a restart.
+func isSamplingUnsupported(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	for _, p := range samplingUnsupportedPatterns {
+		if strings.Contains(msg, p) {
+			return true
+		}
+	}
+	return false
 }
 
 // noWordRegexp matches "no" as a standalone word (not as part of "not", "know", etc.).
@@ -478,7 +520,7 @@ func (w *mcpServerWrapper) handleGetBuildInfo(ctx context.Context, req mcp.CallT
 	}
 	info := slimBuildInfo{
 		CurrentBuild: currentSummary,
-		TotalBuilds:  len(w.daemon.state.GetState().BuildHistory),
+		TotalBuilds:  w.daemon.state.TotalBuilds(),
 		FeatureCount: len(w.daemon.state.GetAccumulatedFeatures()),
 	}
 
@@ -518,7 +560,7 @@ func (w *mcpServerWrapper) handleGetBuildHistory(ctx context.Context, req mcp.Ca
 	resp := BuildHistoryResponse{
 		Builds:              summaries,
 		AccumulatedFeatures: w.daemon.state.GetAccumulatedFeatures(),
-		TotalBuilds:         len(w.daemon.state.GetState().BuildHistory),
+		TotalBuilds:         w.daemon.state.TotalBuilds(),
 	}
 	data, _ := json.MarshalIndent(resp, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
@@ -726,7 +768,7 @@ func (w *mcpServerWrapper) handleBuildResource(ctx context.Context, req mcp.Read
 	info := &BuildInfoResponse{
 		CurrentBuild:        w.daemon.state.GetCurrentBuild(),
 		AccumulatedFeatures: w.daemon.state.GetAccumulatedFeatures(),
-		TotalBuilds:         len(w.daemon.state.GetState().BuildHistory),
+		TotalBuilds:         w.daemon.state.TotalBuilds(),
 		RecentBuilds:        w.daemon.state.GetBuildHistory(5),
 	}
 	data, _ := json.MarshalIndent(info, "", "  ")

--- a/pkg/server/mcpserver_test.go
+++ b/pkg/server/mcpserver_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -27,6 +28,57 @@ func TestRequestRestartApproval_NoSessions(t *testing.T) {
 	}
 	if len(blockers) != 0 {
 		t.Errorf("Expected no blockers, got %v", blockers)
+	}
+}
+
+func TestRequestRestartApproval_UnaskableSessionDoesNotBlock(t *testing.T) {
+	d := &Daemon{version: "test"}
+	w := newMCPServer(d)
+
+	// Simulate a connected session whose context carries no MCP server —
+	// the daemon can never send it a sampling request, so it can never
+	// answer. Such a session must not veto the restart: it hasn't said
+	// "I'm busy", it simply can't be asked.
+	w.sessionsMu.Lock()
+	w.sessions["session-unaskable"] = context.Background()
+	w.sessionsMu.Unlock()
+
+	approved, blockers := w.RequestRestartApproval(context.Background())
+	if !approved {
+		t.Errorf("Expected approved=true for a session that cannot be asked, got blockers %v", blockers)
+	}
+	if len(blockers) != 0 {
+		t.Errorf("Expected no blockers, got %v", blockers)
+	}
+}
+
+func TestIsSamplingUnsupported(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil error", nil, false},
+		// mcp-go: transport session lacks SessionWithSampling (true for all
+		// SSE sessions in mcp-go v0.44.0).
+		{"transport lacks sampling", errors.New("session does not support sampling"), true},
+		// mcp-go: no client session bound to the request context.
+		{"no session in context", errors.New("no active session"), true},
+		// Client rejected the request with JSON-RPC -32601.
+		{"client method not found", errors.New("sampling request failed: Method not found"), true},
+		// Client explicitly says it can't do sampling.
+		{"client says not supported", errors.New("sampling request failed: sampling not supported"), true},
+		// Transient failures stay blocking — the client might genuinely be
+		// busy; the approval deadline bounds these instead.
+		{"timeout stays blocking", context.DeadlineExceeded, false},
+		{"other failure stays blocking", errors.New("sampling request failed: model overloaded"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isSamplingUnsupported(tc.err); got != tc.want {
+				t.Errorf("isSamplingUnsupported(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/pkg/server/protocol.go
+++ b/pkg/server/protocol.go
@@ -6,11 +6,11 @@ import "time"
 type RequestType string
 
 const (
-	ReqPing          RequestType = "ping"
-	ReqShutdown      RequestType = "shutdown"
-	ReqStartEditor   RequestType = "start_editor"
-	ReqStopEditor    RequestType = "stop_editor"
-	ReqListInstances RequestType = "list_instances"
+	ReqPing            RequestType = "ping"
+	ReqShutdown        RequestType = "shutdown"
+	ReqStartEditor     RequestType = "start_editor"
+	ReqStopEditor      RequestType = "stop_editor"
+	ReqListInstances   RequestType = "list_instances"
 	ReqGetLogs         RequestType = "get_logs"
 	ReqStreamLogs      RequestType = "stream_logs"
 	ReqRebuild         RequestType = "rebuild"
@@ -93,6 +93,7 @@ type BuildContribution struct {
 type BuildRecord struct {
 	ID            string              `json:"id"`
 	ProjectPath   string              `json:"project_path"`
+	EnginePath    string              `json:"engine_path,omitempty"`
 	Labels        []string            `json:"labels"`
 	Features      []string            `json:"features"`
 	Contributions []BuildContribution `json:"contributions"`
@@ -214,11 +215,11 @@ type Response struct {
 	Success bool   `json:"success"`
 	Error   string `json:"error,omitempty"`
 
-	Instance  *InstanceInfo   `json:"instance,omitempty"`
-	Instances []InstanceInfo  `json:"instances,omitempty"`
-	Logs      *LogsResponse   `json:"logs,omitempty"`
-	LogLine   *LogLineEvent   `json:"log_line,omitempty"`
-	Pong      *PongResponse   `json:"pong,omitempty"`
+	Instance  *InstanceInfo      `json:"instance,omitempty"`
+	Instances []InstanceInfo     `json:"instances,omitempty"`
+	Logs      *LogsResponse      `json:"logs,omitempty"`
+	LogLine   *LogLineEvent      `json:"log_line,omitempty"`
+	Pong      *PongResponse      `json:"pong,omitempty"`
 	Build     *BuildRecord       `json:"build,omitempty"`
 	Builds    []BuildRecord      `json:"builds,omitempty"`
 	Agent     *AgentInfo         `json:"agent,omitempty"`

--- a/pkg/server/state.go
+++ b/pkg/server/state.go
@@ -192,7 +192,7 @@ func (s *StateStore) appendToArchive(records []BuildRecord) {
 	if err != nil {
 		return
 	}
-	defer f.Close()
+	defer f.Close() //nolint:errcheck
 	enc := json.NewEncoder(f)
 	for _, r := range records {
 		r.Features = nil // derived from prior labels; omit to keep the archive compact

--- a/pkg/server/state.go
+++ b/pkg/server/state.go
@@ -4,8 +4,19 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sync"
 	"time"
+)
+
+const (
+	// maxBuildHistory caps how many full BuildRecords state.json retains.
+	// Older records are rolled to the JSONL archive next to the state file.
+	maxBuildHistory = 100
+
+	// maxAccumulatedFeatures caps the deduplicated feature-label list carried
+	// on the current build.
+	maxAccumulatedFeatures = 200
 )
 
 // PersistentState is the top-level schema for ~/.ue5/state.json.
@@ -13,6 +24,7 @@ type PersistentState struct {
 	CurrentBuild *BuildRecord  `json:"current_build,omitempty"`
 	BuildHistory []BuildRecord `json:"build_history"`
 	ActiveAgents []AgentInfo   `json:"active_agents"`
+	TotalBuilds  int           `json:"total_builds"`
 	LastModified time.Time     `json:"last_modified"`
 }
 
@@ -60,19 +72,35 @@ func (s *StateStore) Load() error {
 		state.ActiveAgents = []AgentInfo{}
 	}
 
+	// Migrate files written before retention caps existed: derive the
+	// lifetime counter, strip per-record accumulated features (derived data
+	// that grew state.json quadratically with build count), and prune the
+	// current build's list.
+	if state.TotalBuilds == 0 {
+		state.TotalBuilds = len(state.BuildHistory)
+	}
+	for i := range state.BuildHistory {
+		state.BuildHistory[i].Features = nil
+	}
+	if state.CurrentBuild != nil {
+		state.CurrentBuild.Features = accumulateFeatures(state.CurrentBuild.Features, nil)
+	}
+
 	s.state = state
+	s.trimHistoryLocked()
 	return nil
 }
 
 // Save writes state to disk atomically (write to temp file, then rename).
 func (s *StateStore) Save() error {
+	// Marshal while holding the lock: the snapshot shares slice backing
+	// arrays with s.state, so encoding after unlock races with in-place
+	// mutations like UpdateBuildStatus.
 	s.mu.RLock()
 	state := s.state
-	s.mu.RUnlock()
-
 	state.LastModified = time.Now()
-
 	data, err := json.MarshalIndent(state, "", "  ")
+	s.mu.RUnlock()
 	if err != nil {
 		return fmt.Errorf("failed to marshal state: %w", err)
 	}
@@ -108,17 +136,68 @@ func (s *StateStore) AddBuildRecord(record BuildRecord) {
 	defer s.mu.Unlock()
 
 	// Accumulate features from previous build
+	var prior []string
 	if s.state.CurrentBuild != nil {
-		existing := make([]string, len(s.state.CurrentBuild.Features))
-		copy(existing, s.state.CurrentBuild.Features)
-		record.Features = append(existing, record.Labels...)
-	} else {
-		record.Features = make([]string, len(record.Labels))
-		copy(record.Features, record.Labels)
+		prior = s.state.CurrentBuild.Features
 	}
+	record.Features = accumulateFeatures(prior, record.Labels)
 
 	s.state.CurrentBuild = &record
-	s.state.BuildHistory = append(s.state.BuildHistory, record)
+
+	// History entries don't carry the accumulated feature list: it's derived
+	// data, and persisting a copy per record made state.json grow
+	// quadratically with build count.
+	entry := record
+	entry.Features = nil
+	s.state.BuildHistory = append(s.state.BuildHistory, entry)
+	s.state.TotalBuilds++
+	s.trimHistoryLocked()
+}
+
+// accumulateFeatures merges new labels into the existing feature list,
+// dropping duplicates and keeping only the most recent maxAccumulatedFeatures.
+func accumulateFeatures(existing, labels []string) []string {
+	merged := make([]string, 0, len(existing)+len(labels))
+	seen := make(map[string]struct{}, len(existing)+len(labels))
+	for _, group := range [][]string{existing, labels} {
+		for _, f := range group {
+			if _, dup := seen[f]; dup {
+				continue
+			}
+			seen[f] = struct{}{}
+			merged = append(merged, f)
+		}
+	}
+	if len(merged) > maxAccumulatedFeatures {
+		merged = append([]string{}, merged[len(merged)-maxAccumulatedFeatures:]...)
+	}
+	return merged
+}
+
+// trimHistoryLocked rolls history beyond maxBuildHistory to the archive file.
+// Caller must hold s.mu.
+func (s *StateStore) trimHistoryLocked() {
+	overflow := len(s.state.BuildHistory) - maxBuildHistory
+	if overflow <= 0 {
+		return
+	}
+	s.appendToArchive(s.state.BuildHistory[:overflow])
+	s.state.BuildHistory = append([]BuildRecord{}, s.state.BuildHistory[overflow:]...)
+}
+
+// appendToArchive appends records to the JSONL history archive. Best-effort:
+// an unwritable archive must never block builds or state persistence.
+func (s *StateStore) appendToArchive(records []BuildRecord) {
+	f, err := os.OpenFile(s.archivePath(), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	for _, r := range records {
+		r.Features = nil // derived from prior labels; omit to keep the archive compact
+		_ = enc.Encode(r)
+	}
 }
 
 // UpdateBuildStatus updates the status of a build record by ID.
@@ -181,6 +260,19 @@ func (s *StateStore) SetActiveAgents(agents []AgentInfo) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.state.ActiveAgents = agents
+}
+
+// TotalBuilds returns the lifetime build count, including records trimmed
+// from history.
+func (s *StateStore) TotalBuilds() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.state.TotalBuilds
+}
+
+// archivePath returns the JSONL file that trimmed history records roll to.
+func (s *StateStore) archivePath() string {
+	return filepath.Join(filepath.Dir(s.path), "history_archive.jsonl")
 }
 
 // GetState returns a snapshot of the full persistent state.

--- a/pkg/server/state_test.go
+++ b/pkg/server/state_test.go
@@ -1,8 +1,12 @@
 package server
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -169,6 +173,212 @@ func TestBuildHistory(t *testing.T) {
 	if history[0].ID != "build-E" {
 		t.Errorf("Expected most recent build 'build-E', got '%s'", history[0].ID)
 	}
+}
+
+// readArchive parses the JSONL history archive written when records are
+// trimmed from build history.
+func readArchive(t *testing.T, path string) []BuildRecord {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read archive: %v", err)
+	}
+	var records []BuildRecord
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if line == "" {
+			continue
+		}
+		var r BuildRecord
+		if err := json.Unmarshal([]byte(line), &r); err != nil {
+			t.Fatalf("parse archive line %q: %v", line, err)
+		}
+		records = append(records, r)
+	}
+	return records
+}
+
+func TestBuildHistoryCappedAndArchived(t *testing.T) {
+	store := NewStateStore()
+	store.path = filepath.Join(t.TempDir(), "state.json")
+
+	total := maxBuildHistory + 5
+	for i := 0; i < total; i++ {
+		store.AddBuildRecord(BuildRecord{
+			ID:     fmt.Sprintf("build-%03d", i),
+			Labels: []string{fmt.Sprintf("feature %03d", i)},
+			Status: BuildStatusSucceeded,
+		})
+	}
+
+	history := store.GetBuildHistory(0)
+	if len(history) != maxBuildHistory {
+		t.Errorf("Expected history capped at %d, got %d", maxBuildHistory, len(history))
+	}
+	if history[0].ID != fmt.Sprintf("build-%03d", total-1) {
+		t.Errorf("Expected most recent build retained, got %s", history[0].ID)
+	}
+	if got := store.TotalBuilds(); got != total {
+		t.Errorf("Expected TotalBuilds %d after trim, got %d", total, got)
+	}
+
+	archived := readArchive(t, store.archivePath())
+	if len(archived) != 5 {
+		t.Fatalf("Expected 5 archived records, got %d", len(archived))
+	}
+	if archived[0].ID != "build-000" {
+		t.Errorf("Expected oldest record archived first, got %s", archived[0].ID)
+	}
+}
+
+func TestHistoryEntriesOmitAccumulatedFeatures(t *testing.T) {
+	store := NewStateStore()
+	store.path = filepath.Join(t.TempDir(), "state.json")
+
+	for _, id := range []string{"a", "b", "c"} {
+		store.AddBuildRecord(BuildRecord{
+			ID:     id,
+			Labels: []string{"feature " + id},
+			Status: BuildStatusSucceeded,
+		})
+	}
+
+	if got := store.GetAccumulatedFeatures(); len(got) != 3 {
+		t.Errorf("Expected 3 accumulated features, got %v", got)
+	}
+	for _, rec := range store.GetBuildHistory(0) {
+		if len(rec.Features) != 0 {
+			t.Errorf("History record %s should not carry accumulated features, got %d", rec.ID, len(rec.Features))
+		}
+	}
+}
+
+func TestAccumulatedFeaturesDeduped(t *testing.T) {
+	store := NewStateStore()
+	store.path = filepath.Join(t.TempDir(), "state.json")
+
+	store.AddBuildRecord(BuildRecord{ID: "1", Labels: []string{"Feature A"}})
+	store.AddBuildRecord(BuildRecord{ID: "2", Labels: []string{"Feature A", "Feature B"}})
+
+	features := store.GetAccumulatedFeatures()
+	if len(features) != 2 || features[0] != "Feature A" || features[1] != "Feature B" {
+		t.Errorf("Expected deduped [Feature A, Feature B], got %v", features)
+	}
+}
+
+func TestAccumulatedFeaturesCapped(t *testing.T) {
+	store := NewStateStore()
+	store.path = filepath.Join(t.TempDir(), "state.json")
+
+	total := maxAccumulatedFeatures + 10
+	for i := 0; i < total; i++ {
+		store.AddBuildRecord(BuildRecord{
+			ID:     fmt.Sprintf("b%d", i),
+			Labels: []string{fmt.Sprintf("feature %04d", i)},
+		})
+	}
+
+	features := store.GetAccumulatedFeatures()
+	if len(features) != maxAccumulatedFeatures {
+		t.Errorf("Expected features capped at %d, got %d", maxAccumulatedFeatures, len(features))
+	}
+	if got := features[len(features)-1]; got != fmt.Sprintf("feature %04d", total-1) {
+		t.Errorf("Expected most recent feature retained last, got %s", got)
+	}
+}
+
+func TestLoadMigratesLegacyBloatedState(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+
+	// Legacy shape: every history record carries the full accumulated
+	// feature list (with duplicates from repeated labels) and there is
+	// no total_builds field.
+	total := maxBuildHistory + 20
+	legacy := PersistentState{ActiveAgents: []AgentInfo{}}
+	features := []string{}
+	for i := 0; i < total; i++ {
+		label := fmt.Sprintf("feature %03d", i)
+		features = append(features, label, label)
+		legacy.BuildHistory = append(legacy.BuildHistory, BuildRecord{
+			ID:       fmt.Sprintf("build-%03d", i),
+			Labels:   []string{label},
+			Features: append([]string{}, features...),
+			Status:   BuildStatusSucceeded,
+		})
+	}
+	last := legacy.BuildHistory[len(legacy.BuildHistory)-1]
+	legacy.CurrentBuild = &last
+
+	data, err := json.Marshal(legacy)
+	if err != nil {
+		t.Fatalf("marshal legacy state: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatalf("write legacy state: %v", err)
+	}
+
+	store := &StateStore{path: path}
+	if err := store.Load(); err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	if got := store.TotalBuilds(); got != total {
+		t.Errorf("Expected TotalBuilds %d from legacy history length, got %d", total, got)
+	}
+	if got := len(store.GetBuildHistory(0)); got != maxBuildHistory {
+		t.Errorf("Expected legacy history trimmed to %d, got %d", maxBuildHistory, got)
+	}
+	for _, rec := range store.GetBuildHistory(0) {
+		if len(rec.Features) != 0 {
+			t.Errorf("Legacy history record %s should have features stripped, got %d", rec.ID, len(rec.Features))
+			break
+		}
+	}
+
+	// Duplicates pruned from the accumulated list (120 unique labels).
+	accumulated := store.GetAccumulatedFeatures()
+	if len(accumulated) != total {
+		t.Errorf("Expected %d deduped accumulated features, got %d", total, len(accumulated))
+	}
+
+	archived := readArchive(t, store.archivePath())
+	if len(archived) != total-maxBuildHistory {
+		t.Errorf("Expected %d archived records, got %d", total-maxBuildHistory, len(archived))
+	}
+
+	// TotalBuilds survives a save/reload cycle.
+	if err := store.Save(); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+	store2 := &StateStore{path: path}
+	if err := store2.Load(); err != nil {
+		t.Fatalf("reload failed: %v", err)
+	}
+	if got := store2.TotalBuilds(); got != total {
+		t.Errorf("Expected TotalBuilds %d after reload, got %d", total, got)
+	}
+}
+
+func TestConcurrentSaveAndUpdate(t *testing.T) {
+	store := NewStateStore()
+	store.path = filepath.Join(t.TempDir(), "state.json")
+
+	store.AddBuildRecord(BuildRecord{ID: "b", Labels: []string{"x"}, Status: BuildStatusBuilding})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			_ = store.Save()
+		}()
+		go func() {
+			defer wg.Done()
+			now := time.Now()
+			store.UpdateBuildStatus("b", BuildStatusSucceeded, &now, "")
+		}()
+	}
+	wg.Wait()
 }
 
 func TestLoadMissingFile(t *testing.T) {


### PR DESCRIPTION
## Summary

Three related fixes for full-rebuild reliability, all on this branch:

### 1. Verify editor exit before UBT starts (b389c65, previously committed)
UBT decides at startup whether to build in hot-reload mode by checking for live UnrealEditor processes. The full-rebuild path now stops the tracked editor, gates on actual process exit (catching orphans the daemon never tracked), deletes stale hot-reload patch binaries, and passes `-NoHotReloadFromIDE`.

### 2. Restart-approval hang fix
`RequestRestartApproval` asks connected MCP clients via sampling whether an editor restart is OK — but in mcp-go v0.44.0 the SSE transport cannot deliver sampling requests at all (`sseSession` doesn't implement `SessionWithSampling`, and tracked connection contexts carry no `serverKey`). Every session was classified "busy", and `executeFullRebuild` retried every 5s forever, so one connected client hung the build indefinitely — before anything compiled.

- Permanent "cannot answer" errors (`isSamplingUnsupported`: no sampling support, no active session, JSON-RPC method-not-found) no longer block — the client hasn't objected, and retrying can never produce an answer. Explicit "yes I'm busy" answers, ambiguous replies, and transient failures (timeouts) still block a round.
- New overall approval deadline (`approvalTimeout`, default 2min): past it the daemon logs the blockers at WARN, emits a `restart_forced` agent event, and proceeds with the build.
- Retry interval and timeout are injectable; the existing blocked-restart test now runs in ms (suite: ~5.3s → ~0.6s).

### 3. state.json retention caps
A real state.json reached 43MB because every history record persisted the full accumulated-features list (quadratic growth). Now: history capped at 100 records (older records roll to `~/.ue5/history_archive.jsonl`), accumulated features deduped and capped at 200, derived features stripped from history entries, lifetime `total_builds` counter added, one-time migration on `Load()`. Also fixes a `Save()` data race by marshalling under the lock.

## Test plan

- [x] `go test ./... -count=1` passes
- [x] `go vet ./...` clean
- [x] New tests: `TestRequestRestartApproval_UnaskableSessionDoesNotBlock`, `TestIsSamplingUnsupported`, `TestFullRebuildProceedsAfterApprovalDeadline` (via injectable `restartApprover`), plus state retention/migration/race coverage
- [ ] Deploy coordination pending: swapping `~/.local/bin/ue5` and restarting the daemon drops live MCP sessions and orphans the running editor — deploy deliberately not done here

🤖 Generated with [Claude Code](https://claude.com/claude-code)