### PR TITLE
Daemon continuity across binary upgrades + durable build-id polling

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: verify
+description: Verify ue5 CLI/daemon changes end-to-end in a sandbox that cannot touch the live fleet daemon
+---
+
+# Verifying ue5 daemon/CLI changes
+
+The daemon serving the IslandSurvival fleet lives at `~/.ue5/server.sock`
+(pid in `~/.ue5/daemon.pid`, MCP SSE :9515, dashboard :9516). Never signal
+it or bind its ports during verification.
+
+## Sandbox recipe
+
+`HomeDir()` derives everything from `$HOME`, and both listen ports have env
+overrides — so a fake home fully isolates a test daemon:
+
+```bash
+E2E=/private/tmp/ue5e2e            # SHORT path — macOS unix sockets cap at
+mkdir -p $E2E/bin $E2E/home        # 104 bytes; deep paths fail with
+go build -o $E2E/bin/ue5 .         # "bind: invalid argument"
+export HOME=$E2E/home UE5_MCP_PORT=19515 UE5_DASHBOARD_PORT=19516
+
+$E2E/bin/ue5 server start          # daemon: $E2E/home/.ue5/server.sock
+$E2E/bin/ue5 server status --json  # {"daemon_running":true,...,"version":"dev"}
+cat $E2E/home/.ue5/daemon.pid      # pid for kill -9 / restart assertions
+```
+
+Source builds report version `dev`, which `ue5 upgrade` always considers
+outdated — so the real upgrade flow (GitHub download included) is drivable
+in the sandbox: it replaces `$E2E/bin/ue5` with the latest release.
+
+## MCP SSE probe (agent surface)
+
+```bash
+curl -sN http://localhost:19515/sse > sse.log &   # endpoint arrives as
+EP=$(grep -m1 "^data: " sse.log | sed 's/^data: //')  # data: /message?sessionId=...
+post() { curl -s -X POST "http://localhost:19515$EP" -H 'Content-Type: application/json' -d "$1" >/dev/null; sleep 0.4; }
+post '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"probe","version":"0"}}}'
+post '{"jsonrpc":"2.0","method":"notifications/initialized"}'
+post '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_build_status","arguments":{}}}'
+grep "^data: " sse.log            # responses stream back on the SSE channel
+```
+
+## Teardown
+
+```bash
+$E2E/bin/ue5 server stop && sleep 1
+pgrep -fl "$E2E/bin/ue5" || rm -rf $E2E
+```
+
+Confirm the live daemon survived your session:
+`kill -0 $(cat ~/.ue5/daemon.pid)`.

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -10,8 +10,10 @@ var serverCmd = &cobra.Command{
 	Long: `The server daemon manages Unreal Editor instances, captures their logs,
 and provides an API for starting, stopping, and querying editor state.
 
-Use 'ue5 server start' to launch the daemon, or commands like 'ue5 server run'
-will auto-start it when needed.`,
+Use 'ue5 server start' to launch the daemon. Commands that need it (run,
+rebuild, logs, status, build-info, agents) auto-start it when the socket is
+dead, so a killed daemon heals on the next query. Only 'stop' and 'kill'
+treat a dead daemon as final.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		_ = cmd.Help()
 	},

--- a/cmd/server_agents.go
+++ b/cmd/server_agents.go
@@ -16,6 +16,10 @@ var serverAgentsCmd = &cobra.Command{
 	Use:   "agents",
 	Short: "List registered AI agents",
 	Run: func(cmd *cobra.Command, args []string) {
+		if err := server.EnsureDaemon(); err != nil {
+			log.Warn("Could not auto-start daemon", "error", err)
+		}
+
 		client := server.NewClient()
 
 		if !client.IsRunning() {

--- a/cmd/server_build_info.go
+++ b/cmd/server_build_info.go
@@ -16,6 +16,12 @@ var serverBuildInfoCmd = &cobra.Command{
 	Use:   "build-info",
 	Short: "Show current build metadata and feature history",
 	Run: func(cmd *cobra.Command, args []string) {
+		// Auto-start so build info survives daemon death: state.json is
+		// persistent, and a freshly started daemon serves it faithfully.
+		if err := server.EnsureDaemon(); err != nil {
+			log.Warn("Could not auto-start daemon", "error", err)
+		}
+
 		client := server.NewClient()
 
 		if !client.IsRunning() {

--- a/cmd/server_status.go
+++ b/cmd/server_status.go
@@ -16,6 +16,12 @@ var serverStatusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Show status of managed editor instances",
 	Run: func(cmd *cobra.Command, args []string) {
+		// Heal a dead daemon rather than reporting it: fleet sessions poll
+		// status, and an always-on daemon is the intended steady state.
+		if err := server.EnsureDaemon(); err != nil {
+			log.Warn("Could not auto-start daemon", "error", err)
+		}
+
 		client := server.NewClient()
 
 		if !client.IsRunning() {

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/Benbentwo/ue5/pkg"
+	"github.com/Benbentwo/ue5/pkg/server"
 	"github.com/charmbracelet/log"
 	"github.com/spf13/cobra"
 )
@@ -25,6 +27,11 @@ This command will:
 1. Check GitHub for the latest release
 2. Compare with your current version
 3. Download and install the new version (with your confirmation)
+4. Restart the server daemon on the new binary if one was running
+   (managed editor instances are stopped with it)
+
+If a build is in progress, the upgrade refuses to run unless --force is
+given, since restarting the daemon aborts the build.
 
 Use --check to only check for updates without installing.
 Use --force to skip the confirmation prompt.`,
@@ -66,7 +73,14 @@ func runUpgrade(cmd *cobra.Command, args []string) {
 		return
 	}
 
+	client := server.NewClient()
+	daemonWasRunning := client.IsRunning()
+
 	if !forceUpgrade {
+		if daemonWasRunning {
+			fmt.Println("\nThe server daemon is running. It will be restarted on the new")
+			fmt.Println("binary after install (managed editor instances are stopped with it).")
+		}
 		fmt.Print("\nDo you want to upgrade? [y/N]: ")
 		reader := bufio.NewReader(os.Stdin)
 		response, err := reader.ReadString('\n')
@@ -81,11 +95,49 @@ func runUpgrade(cmd *cobra.Command, args []string) {
 		}
 	}
 
+	// Restarting the daemon aborts any in-flight build; refuse unless forced.
+	if daemonWasRunning && !forceUpgrade {
+		if resp, err := client.Send(server.Request{ID: "upgrade-build-check", Type: server.ReqGetBuildInfo}); err == nil &&
+			resp.Success && resp.BuildInfo != nil && resp.BuildInfo.CurrentBuild != nil &&
+			resp.BuildInfo.CurrentBuild.Status == server.BuildStatusBuilding {
+			log.Error("A build is in progress; upgrading now would restart the daemon and abort it",
+				"build_id", resp.BuildInfo.CurrentBuild.ID,
+				"labels", resp.BuildInfo.CurrentBuild.Labels)
+			fmt.Println("Wait for the build to finish, or re-run with --force to upgrade anyway.")
+			os.Exit(1)
+		}
+	}
+
 	fmt.Println("\nUpgrading...")
-	if err := pkg.DownloadAndInstall(info); err != nil {
+	installedPath, err := pkg.DownloadAndInstall(info)
+	if err != nil {
 		log.Error("Upgrade failed", "error", err)
 		os.Exit(1)
 	}
 
 	fmt.Printf("\nSuccessfully upgraded to version %s!\n", info.LatestVersion)
+
+	// The install swaps the binary via rename, so an already-running daemon
+	// keeps executing the old (now-unlinked) version safely — but it never
+	// picks up the new one, and before this restart existed an upgrade left
+	// the daemon dead with nothing to revive it (2026-07-09 v0.3.25 outage).
+	// Restart it deliberately: stop old, start new from the installed path.
+	if daemonWasRunning {
+		fmt.Println("Restarting daemon on the new binary (managed editors will be stopped)...")
+		if err := server.StopDaemonAndWait(60 * time.Second); err != nil {
+			log.Warn("Old daemon did not stop; it keeps serving the previous version", "error", err)
+			fmt.Println("Run 'ue5 server stop' then 'ue5 server start' to move it to the new version.")
+			return
+		}
+		if err := server.EnsureDaemonAt(installedPath); err != nil {
+			log.Error("Daemon did not restart after the upgrade", "error", err)
+			fmt.Println("\n*** DAEMON IS STOPPED — run 'ue5 server start' to restore builds and MCP. ***")
+			os.Exit(1)
+		}
+		if pong, err := server.NewClient().Ping(); err == nil {
+			log.Info("Daemon restarted", "version", pong.Version)
+		} else {
+			log.Info("Daemon restarted")
+		}
+	}
 }

--- a/pkg/server/autostart.go
+++ b/pkg/server/autostart.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/charmbracelet/log"
@@ -13,6 +15,19 @@ import (
 // It checks if the socket file exists, attempts a Ping, and if either fails,
 // spawns the daemon as a detached process and polls until it responds.
 func EnsureDaemon() error {
+	// Find our own executable to spawn the daemon
+	self, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("failed to find executable: %w", err)
+	}
+	return EnsureDaemonAt(self)
+}
+
+// EnsureDaemonAt is EnsureDaemon spawning an explicit binary instead of
+// os.Executable(). The upgrade flow needs this: after the binary swap,
+// os.Executable() still describes the process's replaced (unlinked) image,
+// while the install path holds the new version to start the daemon from.
+func EnsureDaemonAt(binPath string) error {
 	client := NewClient()
 
 	// Check if already running
@@ -22,14 +37,8 @@ func EnsureDaemon() error {
 
 	log.Info("Daemon not running, starting it")
 
-	// Find our own executable to spawn the daemon
-	self, err := os.Executable()
-	if err != nil {
-		return fmt.Errorf("failed to find executable: %w", err)
-	}
-
 	// Spawn daemon as detached process
-	cmd := exec.Command(self, "server", "daemon")
+	cmd := exec.Command(binPath, "server", "daemon")
 	cmd.Stdout = nil
 	cmd.Stderr = nil
 	cmd.Stdin = nil
@@ -55,4 +64,45 @@ func EnsureDaemon() error {
 	}
 
 	return fmt.Errorf("daemon did not become responsive within 5 seconds")
+}
+
+// StopDaemonAndWait asks a running daemon to shut down and waits until it has
+// fully exited: the socket stops answering AND the recorded daemon process is
+// gone. Waiting matters when a new daemon starts right after — the old
+// process removes its socket and PID file during teardown, and starting the
+// replacement too early lets that teardown delete the new daemon's files.
+// Returns nil if no daemon was running.
+func StopDaemonAndWait(timeout time.Duration) error {
+	client := NewClient()
+	if !client.IsRunning() {
+		return nil
+	}
+
+	pid := readDaemonPID()
+
+	if _, err := client.Send(Request{ID: "shutdown", Type: ReqShutdown}); err != nil {
+		return fmt.Errorf("failed to send shutdown request: %w", err)
+	}
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if !client.IsRunning() && (pid == 0 || !processAlive(pid)) {
+			return nil
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	return fmt.Errorf("daemon did not exit within %s", timeout)
+}
+
+// readDaemonPID returns the PID from the daemon's PID file, or 0 if unknown.
+func readDaemonPID() int {
+	data, err := os.ReadFile(DaemonPIDFile())
+	if err != nil {
+		return 0
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil || pid <= 0 {
+		return 0
+	}
+	return pid
 }

--- a/pkg/server/autostart_unix.go
+++ b/pkg/server/autostart_unix.go
@@ -13,3 +13,11 @@ func setSysProcAttr(cmd *exec.Cmd) {
 		Setsid: true,
 	}
 }
+
+// processAlive reports whether a process with the given PID exists.
+// Signal 0 performs the existence check without delivering anything;
+// EPERM still means the process exists.
+func processAlive(pid int) bool {
+	err := syscall.Kill(pid, 0)
+	return err == nil || err == syscall.EPERM
+}

--- a/pkg/server/autostart_windows.go
+++ b/pkg/server/autostart_windows.go
@@ -13,3 +13,10 @@ func setSysProcAttr(cmd *exec.Cmd) {
 		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
 	}
 }
+
+// processAlive reports whether a process with the given PID exists.
+// Windows has no cheap signal-0 equivalent; the socket liveness check in
+// StopDaemonAndWait is the effective wait there.
+func processAlive(pid int) bool {
+	return false
+}

--- a/pkg/server/builder.go
+++ b/pkg/server/builder.go
@@ -35,6 +35,7 @@ type BuildOrchestrator struct {
 	mu                    sync.Mutex
 	building              bool
 	queue                 []RebuildRequest
+	pending               *BuildRecord // shared record for queued requests; guarded by mu
 	buildCapture          *LogCapture
 	buildCaptureMu        sync.RWMutex
 }
@@ -76,18 +77,31 @@ func (b *BuildOrchestrator) RequestRebuild(ctx context.Context, req *RebuildRequ
 		b.queue = append(b.queue, *req)
 		log.Info("Rebuild queued for coalescing", "label", req.Label, "agent", req.AgentID, "queue_size", len(b.queue))
 
-		record := &BuildRecord{
-			ID:          fmt.Sprintf("build-%d", time.Now().UnixNano()),
-			ProjectPath: req.ProjectPath,
-			Labels:      []string{req.Label},
-			Contributions: []BuildContribution{{
-				AgentID: req.AgentID,
-				Label:   req.Label,
-			}},
-			Mode:   req.Mode,
-			Status: BuildStatusPending,
+		// All queued requests share ONE pending record, and the coalesced
+		// build keeps its ID when it starts (see the drain in executeBuild).
+		// Minting a fresh ID per queued caller — as this used to — hands out
+		// IDs that never appear in state or events, so clients polling them
+		// wait forever.
+		if b.pending == nil {
+			b.pending = &BuildRecord{
+				ID:            fmt.Sprintf("build-%d", time.Now().UnixNano()),
+				ProjectPath:   req.ProjectPath,
+				Labels:        []string{},
+				Contributions: []BuildContribution{},
+				Mode:          BuildModeHotReload,
+				Status:        BuildStatusPending,
+			}
 		}
-		return record, nil
+		b.pending.Labels = append(b.pending.Labels, req.Label)
+		b.pending.Contributions = append(b.pending.Contributions, BuildContribution{
+			AgentID: req.AgentID,
+			Label:   req.Label,
+		})
+		// Mode escalation: "full" wins over "hot_reload"
+		if req.Mode == BuildModeFull {
+			b.pending.Mode = BuildModeFull
+		}
+		return b.pendingCopyLocked(), nil
 	}
 
 	// Start build immediately
@@ -227,11 +241,38 @@ func (b *BuildOrchestrator) executeBuild(ctx context.Context, record *BuildRecor
 		queued := b.queue
 		b.queue = nil
 		nextRecord := b.createRecord(queued)
+		if b.pending != nil {
+			// Queued callers hold the pending record's ID; the coalesced
+			// build must keep it so those IDs stay pollable end-to-end.
+			nextRecord.ID = b.pending.ID
+			b.pending = nil
+		}
 		b.building = true
 		go b.executeBuild(ctx, nextRecord)
 		log.Info("Starting coalesced build from queue", "build_id", nextRecord.ID, "coalesced_count", len(queued))
 	}
 	b.mu.Unlock()
+}
+
+// PendingBuild returns a copy of the queued-but-not-started coalesced build
+// record, or nil when nothing is queued. Lets status lookups resolve IDs that
+// were handed out for queued requests before the build starts.
+func (b *BuildOrchestrator) PendingBuild() *BuildRecord {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.pendingCopyLocked()
+}
+
+// pendingCopyLocked deep-copies the pending record's caller-visible slices so
+// later queue merges don't mutate a record already returned. Caller holds mu.
+func (b *BuildOrchestrator) pendingCopyLocked() *BuildRecord {
+	if b.pending == nil {
+		return nil
+	}
+	record := *b.pending
+	record.Labels = append([]string(nil), b.pending.Labels...)
+	record.Contributions = append([]BuildContribution(nil), b.pending.Contributions...)
+	return &record
 }
 
 // executeFullRebuild performs a strict stop -> build -> restart cycle.

--- a/pkg/server/builder_test.go
+++ b/pkg/server/builder_test.go
@@ -497,3 +497,145 @@ func TestHotReloadSkipsApprovalCheck(t *testing.T) {
 		t.Error("Approval check should NOT be called for hot reload")
 	}
 }
+
+// waitForOrchestratorIdle blocks until no build is running or queued. The
+// orchestrator clears its building flag only after the final state Save, so
+// idleness also means background goroutines are done touching the state file
+// — required before t.TempDir cleanup runs.
+func waitForOrchestratorIdle(t *testing.T, b *BuildOrchestrator) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for b.IsBuilding() || b.PendingBuild() != nil {
+		if time.Now().After(deadline) {
+			t.Fatal("orchestrator did not quiesce within 5s")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestQueuedRequestsShareStableBuildID covers the ID-continuity contract for
+// queued rebuilds: every caller that queues while a build is in flight gets
+// the SAME pending id, and the coalesced build keeps that id when it starts,
+// so the ids handed out are pollable across their whole lifecycle. The old
+// behavior minted a fresh id per queued caller and a different one again for
+// the coalesced build — ids that never appeared in state or events.
+func TestQueuedRequestsShareStableBuildID(t *testing.T) {
+	state := NewStateStore()
+	state.path = filepath.Join(t.TempDir(), "state.json")
+	agents := NewAgentRegistry()
+	manager := NewInstanceManager()
+	b := NewBuildOrchestrator(manager, state, agents)
+
+	release := make(chan struct{})
+	started := make(chan struct{})
+	var once sync.Once
+	b.buildRunner = func(record *BuildRecord) error {
+		once.Do(func() { close(started) })
+		<-release // first build blocks; coalesced build sails through (closed)
+		return nil
+	}
+	b.restartApprover = func(ctx context.Context) (bool, []string) { return true, nil }
+
+	first, err := b.RequestRebuild(context.Background(), &RebuildRequest{
+		ProjectPath: "/test/MyGame.uproject", Mode: BuildModeFull, Label: "first", AgentID: "agent-A",
+	})
+	if err != nil {
+		t.Fatalf("first request failed: %v", err)
+	}
+	<-started // first build is now in flight (and recorded as current)
+
+	second, err := b.RequestRebuild(context.Background(), &RebuildRequest{
+		ProjectPath: "/test/MyGame.uproject", Mode: BuildModeHotReload, Label: "second", AgentID: "agent-B",
+	})
+	if err != nil {
+		t.Fatalf("second request failed: %v", err)
+	}
+	third, err := b.RequestRebuild(context.Background(), &RebuildRequest{
+		ProjectPath: "/test/MyGame.uproject", Mode: BuildModeFull, Label: "third", AgentID: "agent-C",
+	})
+	if err != nil {
+		t.Fatalf("third request failed: %v", err)
+	}
+
+	if second.Status != BuildStatusPending || third.Status != BuildStatusPending {
+		t.Fatalf("queued requests should be pending, got %q / %q", second.Status, third.Status)
+	}
+	if second.ID != third.ID {
+		t.Fatalf("queued callers must share one pending id, got %q vs %q", second.ID, third.ID)
+	}
+	if second.ID == first.ID {
+		t.Fatalf("pending id must differ from the in-flight build id %q", first.ID)
+	}
+	if len(third.Labels) != 2 || third.Labels[0] != "second" || third.Labels[1] != "third" {
+		t.Errorf("pending record should accumulate queued labels, got %v", third.Labels)
+	}
+	if third.Mode != BuildModeFull {
+		t.Errorf("full mode must win escalation, got %q", third.Mode)
+	}
+
+	// The pending id resolves while queued.
+	if p := b.PendingBuild(); p == nil || p.ID != second.ID {
+		t.Fatalf("PendingBuild should expose the queued record, got %+v", p)
+	}
+
+	close(release)
+
+	// The coalesced build must reach state under the SAME id the callers hold.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		current := state.GetCurrentBuild()
+		if current != nil && current.ID == second.ID && current.Status == BuildStatusSucceeded {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("coalesced build never became current under the pending id %q; current=%+v", second.ID, current)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if p := b.PendingBuild(); p != nil {
+		t.Errorf("pending record should clear once the coalesced build starts, got %+v", p)
+	}
+	waitForOrchestratorIdle(t, b)
+}
+
+// TestPendingBuildCopyIsIsolated guards against later queue merges mutating a
+// record already returned to a caller (shared slice backing arrays).
+func TestPendingBuildCopyIsIsolated(t *testing.T) {
+	state := NewStateStore()
+	state.path = filepath.Join(t.TempDir(), "state.json")
+	b := NewBuildOrchestrator(NewInstanceManager(), state, NewAgentRegistry())
+
+	release := make(chan struct{})
+	started := make(chan struct{})
+	var once sync.Once
+	b.buildRunner = func(record *BuildRecord) error {
+		once.Do(func() { close(started) })
+		<-release
+		return nil
+	}
+	b.restartApprover = func(ctx context.Context) (bool, []string) { return true, nil }
+
+	if _, err := b.RequestRebuild(context.Background(), &RebuildRequest{
+		ProjectPath: "/test/MyGame.uproject", Mode: BuildModeFull, Label: "first", AgentID: "agent-A",
+	}); err != nil {
+		t.Fatalf("first request failed: %v", err)
+	}
+	<-started
+
+	second, _ := b.RequestRebuild(context.Background(), &RebuildRequest{
+		ProjectPath: "/test/MyGame.uproject", Mode: BuildModeFull, Label: "second", AgentID: "agent-B",
+	})
+	labelsBefore := append([]string(nil), second.Labels...)
+
+	_, _ = b.RequestRebuild(context.Background(), &RebuildRequest{
+		ProjectPath: "/test/MyGame.uproject", Mode: BuildModeFull, Label: "third", AgentID: "agent-C",
+	})
+
+	if len(second.Labels) != len(labelsBefore) {
+		t.Errorf("returned record mutated by later queue merge: %v -> %v", labelsBefore, second.Labels)
+	}
+
+	close(release)
+	waitForOrchestratorIdle(t, b)
+}

--- a/pkg/server/mcpserver.go
+++ b/pkg/server/mcpserver.go
@@ -275,7 +275,9 @@ func (w *mcpServerWrapper) registerTools() {
 			mcp.WithDescription("Trigger a rebuild of the UE5 project. "+
 				"Use mode 'full' for stop->build->restart cycle, "+
 				"or 'hot_reload' to build while editor stays running. "+
-				"Requests are coalesced when multiple agents request rebuilds concurrently."),
+				"Requests are coalesced when multiple agents request rebuilds concurrently. "+
+				"Poll the returned build id with get_build_status(build_id=...) — it stays "+
+				"resolvable through queueing, coalescing, and later builds superseding it."),
 			mcp.WithString("project_path", mcp.Required(),
 				mcp.Description("Absolute path to the .uproject file")),
 			mcp.WithString("engine_path", mcp.Required(),
@@ -324,10 +326,17 @@ func (w *mcpServerWrapper) registerTools() {
 	// If status == "failed", call get_build_failure with the ID for details.
 	w.mcp.AddTool(
 		mcp.NewTool("get_build_status",
-			mcp.WithDescription("Minimal status check for the current build. "+
+			mcp.WithDescription("Minimal status check for a build. "+
 				"Returns only {id, prompt, status} — designed for cheap polling. "+
+				"Pass build_id to poll YOUR build: it resolves even after another build "+
+				"supersedes it as current (looked up in queued + history records too). "+
+				"Omit build_id for the current build. "+
 				"If status is 'failed', call get_build_failure with the id to fetch error details. "+
-				"Returns empty id when no build has ever run."),
+				"Returns empty id when no build has ever run. "+
+				"An unknown build_id is an error — it means the daemon restarted since the id "+
+				"was issued; re-submit the rebuild rather than continuing to poll."),
+			mcp.WithString("build_id",
+				mcp.Description("Build ID to look up (from a rebuild response). Defaults to the current build.")),
 		),
 		w.handleGetBuildStatus,
 	)
@@ -530,16 +539,49 @@ func (w *mcpServerWrapper) handleGetBuildInfo(ctx context.Context, req mcp.CallT
 
 // handleGetBuildStatus returns the minimal {id, prompt, status} polling shape.
 // Joins coalesced labels with " + " so the prompt reads naturally.
+//
+// With build_id set, the lookup covers current + pending + history, so an
+// agent's id keeps resolving after its build is superseded as current (the
+// 2026-07-09 incident: a queued "manual" build replaced current_build 3ms
+// after an agent's build succeeded, and the agent — with no way to query its
+// own id — polled the current build forever).
 func (w *mcpServerWrapper) handleGetBuildStatus(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	current := w.daemon.state.GetCurrentBuild()
+	buildID := req.GetString("build_id", "")
+	record := w.lookupBuild(buildID)
+	if record == nil && buildID != "" {
+		return mcp.NewToolResultError(fmt.Sprintf(
+			"unknown build id %q: not the current, queued, or any recorded build. "+
+				"The daemon has likely restarted since this id was issued (queued requests "+
+				"do not survive restarts) — re-submit the rebuild or check get_build_history.",
+			buildID)), nil
+	}
 	resp := BuildStatusResponse{}
-	if current != nil {
-		resp.ID = current.ID
-		resp.Status = current.Status
-		resp.Prompt = strings.Join(current.Labels, " + ")
+	if record != nil {
+		resp.ID = record.ID
+		resp.Status = record.Status
+		resp.Prompt = strings.Join(record.Labels, " + ")
 	}
 	data, _ := json.Marshal(resp) // no indent — every byte counts on this path
 	return mcp.NewToolResultText(string(data)), nil
+}
+
+// lookupBuild resolves a build id against the current build, the pending
+// coalesced build, then history. An empty id means "the current build".
+func (w *mcpServerWrapper) lookupBuild(buildID string) *BuildRecord {
+	current := w.daemon.state.GetCurrentBuild()
+	if buildID == "" || (current != nil && current.ID == buildID) {
+		return current
+	}
+	if pending := w.daemon.builder.PendingBuild(); pending != nil && pending.ID == buildID {
+		return pending
+	}
+	for _, b := range w.daemon.state.GetBuildHistory(0) {
+		if b.ID == buildID {
+			record := b
+			return &record
+		}
+	}
+	return nil
 }
 
 // handleGetBuildHistory returns the full audit trail. Capped at 50 to bound

--- a/pkg/server/mcpserver_buildstatus_test.go
+++ b/pkg/server/mcpserver_buildstatus_test.go
@@ -1,0 +1,163 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// buildStatusDaemon assembles the minimal daemon wiring handleGetBuildStatus
+// touches: a state store and a build orchestrator.
+func buildStatusDaemon(t *testing.T) (*Daemon, *mcpServerWrapper) {
+	t.Helper()
+	state := NewStateStore()
+	state.path = filepath.Join(t.TempDir(), "state.json")
+	d := &Daemon{version: "test", state: state}
+	d.builder = NewBuildOrchestrator(NewInstanceManager(), state, NewAgentRegistry())
+	return d, newMCPServer(d)
+}
+
+func callGetBuildStatus(t *testing.T, w *mcpServerWrapper, args map[string]any) (*mcp.CallToolResult, BuildStatusResponse) {
+	t.Helper()
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = args
+	res, err := w.handleGetBuildStatus(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleGetBuildStatus returned transport error: %v", err)
+	}
+	var status BuildStatusResponse
+	if !res.IsError {
+		text := res.Content[0].(mcp.TextContent).Text
+		if err := json.Unmarshal([]byte(text), &status); err != nil {
+			t.Fatalf("response is not a BuildStatusResponse: %v (%s)", err, text)
+		}
+	}
+	return res, status
+}
+
+// TestGetBuildStatusByIDResolvesSupersededBuild reproduces the 2026-07-09
+// incident shape: an agent's build succeeds, a "manual" build immediately
+// replaces it as current, and the agent polls its own id. The lookup must
+// resolve the superseded id from history instead of leaving the agent
+// staring at someone else's build forever.
+func TestGetBuildStatusByIDResolvesSupersededBuild(t *testing.T) {
+	d, w := buildStatusDaemon(t)
+
+	agentBuild := BuildRecord{
+		ID:     "build-agent",
+		Labels: []string{"delete_asset round 4"},
+		Status: BuildStatusBuilding,
+	}
+	d.state.AddBuildRecord(agentBuild)
+	now := time.Now()
+	d.state.UpdateBuildStatus("build-agent", BuildStatusSucceeded, &now, "")
+
+	manualBuild := BuildRecord{
+		ID:     "build-manual",
+		Labels: []string{"manual"},
+		Status: BuildStatusBuilding,
+	}
+	d.state.AddBuildRecord(manualBuild)
+
+	res, status := callGetBuildStatus(t, w, map[string]any{"build_id": "build-agent"})
+	if res.IsError {
+		t.Fatalf("expected success for superseded id, got error: %+v", res.Content)
+	}
+	if status.ID != "build-agent" || status.Status != BuildStatusSucceeded {
+		t.Errorf("expected superseded build to resolve as succeeded, got %+v", status)
+	}
+	if status.Prompt != "delete_asset round 4" {
+		t.Errorf("expected the agent's own prompt, got %q", status.Prompt)
+	}
+}
+
+func TestGetBuildStatusDefaultsToCurrent(t *testing.T) {
+	d, w := buildStatusDaemon(t)
+	d.state.AddBuildRecord(BuildRecord{ID: "build-current", Labels: []string{"now"}, Status: BuildStatusBuilding})
+
+	res, status := callGetBuildStatus(t, w, nil)
+	if res.IsError {
+		t.Fatalf("expected success, got error: %+v", res.Content)
+	}
+	if status.ID != "build-current" || status.Status != BuildStatusBuilding {
+		t.Errorf("expected current build, got %+v", status)
+	}
+}
+
+func TestGetBuildStatusNoBuildsYet(t *testing.T) {
+	_, w := buildStatusDaemon(t)
+
+	res, status := callGetBuildStatus(t, w, nil)
+	if res.IsError {
+		t.Fatalf("no-builds-yet must not be an error: %+v", res.Content)
+	}
+	if status.ID != "" {
+		t.Errorf("expected empty id sentinel, got %+v", status)
+	}
+}
+
+// TestGetBuildStatusUnknownIDIsExplicitError: an id the daemon has never seen
+// (e.g. issued before a restart) must fail loudly, not silently return some
+// other build — a polling agent needs the signal to re-submit.
+func TestGetBuildStatusUnknownIDIsExplicitError(t *testing.T) {
+	d, w := buildStatusDaemon(t)
+	d.state.AddBuildRecord(BuildRecord{ID: "build-current", Labels: []string{"now"}, Status: BuildStatusBuilding})
+
+	res, _ := callGetBuildStatus(t, w, map[string]any{"build_id": "build-from-before-restart"})
+	if !res.IsError {
+		t.Fatal("expected an error result for an unknown build id")
+	}
+	text := res.Content[0].(mcp.TextContent).Text
+	if !strings.Contains(text, "unknown build id") || !strings.Contains(text, "build-from-before-restart") {
+		t.Errorf("error should name the unknown id, got %q", text)
+	}
+}
+
+// TestGetBuildStatusResolvesPendingQueuedBuild: ids handed out while queued
+// must resolve (as pending) before the coalesced build starts.
+func TestGetBuildStatusResolvesPendingQueuedBuild(t *testing.T) {
+	d, w := buildStatusDaemon(t)
+
+	release := make(chan struct{})
+	started := make(chan struct{})
+	d.builder.buildRunner = func(record *BuildRecord) error {
+		select {
+		case <-started:
+		default:
+			close(started)
+		}
+		<-release
+		return nil
+	}
+	d.builder.restartApprover = func(ctx context.Context) (bool, []string) { return true, nil }
+
+	if _, err := d.builder.RequestRebuild(context.Background(), &RebuildRequest{
+		ProjectPath: "/test/MyGame.uproject", Mode: BuildModeFull, Label: "first", AgentID: "agent-A",
+	}); err != nil {
+		t.Fatalf("first request failed: %v", err)
+	}
+	<-started
+
+	queued, err := d.builder.RequestRebuild(context.Background(), &RebuildRequest{
+		ProjectPath: "/test/MyGame.uproject", Mode: BuildModeFull, Label: "queued-work", AgentID: "agent-B",
+	})
+	if err != nil {
+		t.Fatalf("queued request failed: %v", err)
+	}
+
+	res, status := callGetBuildStatus(t, w, map[string]any{"build_id": queued.ID})
+	if res.IsError {
+		t.Fatalf("queued id must resolve, got error: %+v", res.Content)
+	}
+	if status.ID != queued.ID || status.Status != BuildStatusPending {
+		t.Errorf("expected pending status for queued id, got %+v", status)
+	}
+
+	close(release)
+	waitForOrchestratorIdle(t, d.builder)
+}

--- a/pkg/upgrade.go
+++ b/pkg/upgrade.go
@@ -174,10 +174,14 @@ func compareVersions(v1, v2 string) int {
 	return 0
 }
 
-// DownloadAndInstall downloads the latest release and installs it
-func DownloadAndInstall(info *UpgradeInfo) error {
+// DownloadAndInstall downloads the latest release and installs it over the
+// current executable. Returns the path the binary was installed to so callers
+// can act on the new binary (e.g. restart the daemon from it) — after the
+// swap, os.Executable() still resolves to the replaced process image and must
+// not be trusted for that.
+func DownloadAndInstall(info *UpgradeInfo) (string, error) {
 	if info.DownloadURL == "" {
-		return fmt.Errorf("no download URL available for your platform")
+		return "", fmt.Errorf("no download URL available for your platform")
 	}
 
 	log.Info("Downloading", "url", info.DownloadURL)
@@ -185,13 +189,13 @@ func DownloadAndInstall(info *UpgradeInfo) error {
 	// Download to temp file
 	tmpDir, err := os.MkdirTemp("", "ue5-upgrade-*")
 	if err != nil {
-		return fmt.Errorf("failed to create temp directory: %w", err)
+		return "", fmt.Errorf("failed to create temp directory: %w", err)
 	}
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	archivePath := filepath.Join(tmpDir, info.AssetName)
 	if err := downloadFile(info.DownloadURL, archivePath); err != nil {
-		return fmt.Errorf("failed to download: %w", err)
+		return "", fmt.Errorf("failed to download: %w", err)
 	}
 
 	log.Info("Download complete", "size", getFileSize(archivePath))
@@ -203,27 +207,27 @@ func DownloadAndInstall(info *UpgradeInfo) error {
 	}
 
 	if err := extractArchive(archivePath, tmpDir); err != nil {
-		return fmt.Errorf("failed to extract: %w", err)
+		return "", fmt.Errorf("failed to extract: %w", err)
 	}
 
 	// Get current executable path
 	currentExe, err := os.Executable()
 	if err != nil {
-		return fmt.Errorf("failed to get current executable path: %w", err)
+		return "", fmt.Errorf("failed to get current executable path: %w", err)
 	}
 	currentExe, err = filepath.EvalSymlinks(currentExe)
 	if err != nil {
-		return fmt.Errorf("failed to resolve symlinks: %w", err)
+		return "", fmt.Errorf("failed to resolve symlinks: %w", err)
 	}
 
 	log.Info("Installing", "path", currentExe)
 
 	// Replace the current binary
 	if err := replaceBinary(extractedBinary, currentExe); err != nil {
-		return fmt.Errorf("failed to install: %w", err)
+		return "", fmt.Errorf("failed to install: %w", err)
 	}
 
-	return nil
+	return currentExe, nil
 }
 
 // downloadFile downloads a file from URL to the specified path
@@ -295,36 +299,45 @@ func extractZip(archivePath, destDir string) error {
 	return nil
 }
 
-// replaceBinary replaces the current binary with a new one
+// replaceBinary replaces the current binary with a new one.
+//
+// The swap MUST be a rename(2), never a write to the existing path: copying
+// over the live path (os.Create truncates in place) rewrites the inode that a
+// running daemon is executing from. macOS invalidates the code signature of a
+// modified running binary and SIGKILLs the process as soon as it faults in a
+// page from the file — this is exactly how the v0.3.25 upgrade silently killed
+// the daemon. A rename swaps in a new inode and leaves the old one intact for
+// any process still running it.
 func replaceBinary(newBinary, currentBinary string) error {
 	// Check if new binary exists
 	if _, err := os.Stat(newBinary); os.IsNotExist(err) {
 		return fmt.Errorf("new binary not found at %s", newBinary)
 	}
 
-	// Make the new binary executable
-	if err := os.Chmod(newBinary, 0755); err != nil {
-		return fmt.Errorf("failed to make binary executable: %w", err)
+	// Stage next to the target: rename(2) is atomic only within a filesystem,
+	// and the download's temp dir may be on a different volume.
+	staged := currentBinary + ".new"
+	if err := copyFile(newBinary, staged); err != nil {
+		return fmt.Errorf("failed to stage new binary: %w", err)
+	}
+	if err := os.Chmod(staged, 0755); err != nil {
+		_ = os.Remove(staged)
+		return fmt.Errorf("failed to make staged binary executable: %w", err)
 	}
 
-	// On Unix, we can rename over the running binary
-	// On Windows, we need to rename the old binary first
+	// Windows can't rename over a running executable; move it aside first.
 	if runtime.GOOS == "windows" {
 		oldBinary := currentBinary + ".old"
 		_ = os.Remove(oldBinary) // Remove any existing old binary
 		if err := os.Rename(currentBinary, oldBinary); err != nil {
+			_ = os.Remove(staged)
 			return fmt.Errorf("failed to rename old binary: %w", err)
 		}
 	}
 
-	// Copy new binary to current location
-	if err := copyFile(newBinary, currentBinary); err != nil {
-		return fmt.Errorf("failed to copy new binary: %w", err)
-	}
-
-	// Make sure the new binary is executable
-	if err := os.Chmod(currentBinary, 0755); err != nil {
-		return fmt.Errorf("failed to make installed binary executable: %w", err)
+	if err := os.Rename(staged, currentBinary); err != nil {
+		_ = os.Remove(staged)
+		return fmt.Errorf("failed to install new binary: %w", err)
 	}
 
 	return nil

--- a/pkg/upgrade_unix_test.go
+++ b/pkg/upgrade_unix_test.go
@@ -1,0 +1,77 @@
+//go:build darwin || linux
+
+package pkg
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+// TestReplaceBinarySwapsInode is the contract that keeps a running daemon
+// alive through upgrades: the installed path must get a NEW inode via
+// rename(2), never a truncate-and-rewrite of the existing one. Overwriting
+// the inode a running process executes from invalidates its code signature
+// on macOS and the kernel SIGKILLs it on the next page fault — the
+// 2026-07-09 v0.3.25 upgrade killed the daemon exactly this way.
+func TestReplaceBinarySwapsInode(t *testing.T) {
+	dir := t.TempDir()
+
+	target := filepath.Join(dir, "ue5")
+	if err := os.WriteFile(target, []byte("old-binary"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	inodeBefore := inodeOf(t, target)
+
+	// Source lives elsewhere (the real flow stages from a temp download dir).
+	srcDir := filepath.Join(dir, "download")
+	if err := os.MkdirAll(srcDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	src := filepath.Join(srcDir, "ue5")
+	if err := os.WriteFile(src, []byte("new-binary"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := replaceBinary(src, target); err != nil {
+		t.Fatalf("replaceBinary failed: %v", err)
+	}
+
+	content, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "new-binary" {
+		t.Errorf("target content = %q, want new binary", content)
+	}
+
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0755 {
+		t.Errorf("installed binary mode = %v, want 0755", info.Mode().Perm())
+	}
+
+	if inodeAfter := inodeOf(t, target); inodeAfter == inodeBefore {
+		t.Errorf("target kept inode %d: replacement rewrote the running binary in place instead of renaming a new inode over it", inodeBefore)
+	}
+
+	if _, err := os.Stat(target + ".new"); !os.IsNotExist(err) {
+		t.Errorf("staging file %s.new left behind (err=%v)", target, err)
+	}
+}
+
+func inodeOf(t *testing.T, path string) uint64 {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Fatal("stat does not expose inode on this platform")
+	}
+	return st.Ino
+}


### PR DESCRIPTION
## Why

The v0.3.25 upgrade (2026-07-09 ~21:57) silently killed the running daemon and blocked every IslandSurvival fleet session with "Unable to connect" until a manual `ue5 server start` five minutes later — unattended, the outage would have been indefinite.

Root cause: `replaceBinary` copied the new binary **over the live path** (`os.Create` truncates the inode in place). Modifying a running signed binary invalidates its code signature on macOS, and the kernel SIGKILLs the process on its next page fault from that file — a delayed fuse, which is why the upgrade looked successful and the daemon's death looked unrelated. Nothing in the upgrade path stops or restarts the daemon.

A second incident rode along: an MCP rebuild (`build-1783648951322485000`, 22:02:31) **succeeded**, but a queued dashboard "manual" build drained 3ms later and replaced `current_build`. Agents had no by-id lookup, so they polled someone else's build forever. Worse, requests queued during a build were handed freshly minted build IDs that were never persisted anywhere — the coalesced build got a different ID.

## What changed

**Upgrade flow** (`pkg/upgrade.go`, `cmd/upgrade.go`)
- `replaceBinary` stages next to the target and swaps via `rename(2)` — new inode installed; a running daemon keeps executing the old one safely
- If a daemon was running, the upgrade stops it after install (`StopDaemonAndWait` waits for real process exit) and restarts it from the installed binary (`EnsureDaemonAt` — `os.Executable()` lies after a swap), with loud output if either step fails
- Refuses to abort an in-flight build unless `--force`

**Dead-socket healing** (`cmd/server_{status,build_info,agents}.go`)
- `status` / `build-info` / `agents` now `EnsureDaemon()` like `run`/`rebuild`/`logs` already did — any fleet query heals a dead daemon. `stop`/`kill` keep "not running is final" semantics.

**Build-id durability** (`pkg/server/builder.go`, `pkg/server/mcpserver.go`)
- Requests queued during a build share **one** pending record, and the coalesced build keeps its ID end-to-end
- `get_build_status` accepts `build_id`, resolving current → pending → history; unknown ids return an explicit "daemon likely restarted — re-submit" error instead of silently showing the current build

## Verification

Beyond unit + race suites, the flows were driven end-to-end against a sandboxed daemon (fake `$HOME`, port overrides; recipe persisted at `.claude/skills/verify/SKILL.md`):

- `upgrade --force` with no daemon: real GitHub download, inode swap (rename), no daemon spawned
- `upgrade --force` with live daemon: binary swapped harmlessly under it, then restart — PID changed, daemon version `dev → 0.3.25`, old daemon exited cleanly
- `kill -9` daemon (incident simulation, stale socket) → `server status` auto-heals with a fresh daemon
- MCP over real SSE: unknown `build_id` → explicit error; no-args → unchanged `{"id":"","prompt":"","status":""}` sentinel
- Repeat `upgrade` → "already running the latest version"

## Reviewer notes

- ⚠️ **The next upgrade is the last unsafe one**: the installed v0.3.25 still runs the old path, so upgrading *to* the release containing this fix will kill the daemon once more — plan a `ue5 server start` after it. Every upgrade after that self-heals.
- Daemon restarts still drop tracked editor instances and MCP/SSE connections (instances aren't persisted); the upgrade prints this and sessions re-`start_editor`.
- Deliberate semantics changes: `server status` now *ensures* the daemon rather than just observing it, and unattended `ue5 upgrade --force` will abort an in-flight build by design.
- Queued rebuilds still don't survive daemon restarts — chosen over queue persistence (auto-resuming builds on daemon start is riskier); the unknown-id error gives agents the re-submit signal.